### PR TITLE
fix: fix valgrind version checks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,13 +17,13 @@ use log::log_enabled;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const MONGODB_TRACER_VERSION: &str = "cs-mongo-tracer-v0.2.0";
-pub const VALGRIND_CODSPEED_VERSION: &str = "3.24.0-0codspeed";
-const VALGRIND_CODSPEED_VERSION_DEB_POST_REV: u32 = 1;
+
+const VALGRIND_CODSPEED_BASE_VERSION: &str = "3.24.0";
 lazy_static! {
-    pub static ref VALGRIND_CODSPEED_DEB_VERSION: String = format!(
-        "{}{}",
-        VALGRIND_CODSPEED_VERSION, VALGRIND_CODSPEED_VERSION_DEB_POST_REV
-    );
+    pub static ref VALGRIND_CODSPEED_VERSION: String =
+        format!("{VALGRIND_CODSPEED_BASE_VERSION}.codspeed");
+    pub static ref VALGRIND_CODSPEED_DEB_VERSION: String =
+        format!("{VALGRIND_CODSPEED_BASE_VERSION}-0codspeed1");
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -43,7 +43,6 @@ async fn main() {
             }
         }
         clean_logger();
-
         std::process::exit(1);
     }
 }

--- a/src/run/runner/valgrind/setup.rs
+++ b/src/run/runner/valgrind/setup.rs
@@ -77,7 +77,7 @@ fn is_valgrind_installed() -> bool {
         }
 
         let version = String::from_utf8_lossy(&version_output.stdout);
-        version.contains(VALGRIND_CODSPEED_VERSION)
+        version.contains(VALGRIND_CODSPEED_VERSION.as_str())
     } else {
         false
     }


### PR DESCRIPTION
Avoid using the deb package version since --version only outputs our version
