### PR TITLE
feat: allow specifying oauth token through CLI

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -12,15 +12,13 @@ pub struct CodSpeedAPIClient {
     unauthenticated_gql_client: GQLClient,
 }
 
-impl TryFrom<&Cli> for CodSpeedAPIClient {
+impl TryFrom<(&Cli, &CodSpeedConfig)> for CodSpeedAPIClient {
     type Error = Error;
-    fn try_from(args: &Cli) -> Result<Self> {
-        let codspeed_config = CodSpeedConfig::load()?;
-
+    fn try_from((args, codspeed_config): (&Cli, &CodSpeedConfig)) -> Result<Self> {
         Ok(Self {
-            gql_client: build_gql_api_client(&codspeed_config, args.api_url.clone(), true),
+            gql_client: build_gql_api_client(codspeed_config, args.api_url.clone(), true),
             unauthenticated_gql_client: build_gql_api_client(
-                &codspeed_config,
+                codspeed_config,
                 args.api_url.clone(),
                 false,
             ),

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -133,11 +133,14 @@ impl RunArgs {
     }
 }
 
-pub async fn run(args: RunArgs, api_client: &CodSpeedAPIClient) -> Result<()> {
+pub async fn run(
+    args: RunArgs,
+    api_client: &CodSpeedAPIClient,
+    codspeed_config: &CodSpeedConfig,
+) -> Result<()> {
     let output_json = args.message_format == Some(MessageFormat::Json);
     let mut config = Config::try_from(args)?;
     let provider = run_environment::get_provider(&config)?;
-    let codspeed_config = CodSpeedConfig::load()?;
     let logger = Logger::new(&provider)?;
 
     if provider.get_run_environment() != RunEnvironment::Local {


### PR DESCRIPTION
- Fixed an issue where commit hash could not be found when doing local runs while preparing upload metadata
- Allow specifying the oauth token through cli argument/env var and do not rely on config file when not necessary