### PR TITLE
feat: enable valgrind fair-sched

### DIFF
--- a/src/run/runner/valgrind/measure.rs
+++ b/src/run/runner/valgrind/measure.rs
@@ -33,6 +33,7 @@ lazy_static! {
                 "--compress-strings=no",
                 "--combine-dumps=yes",
                 "--dump-line=no",
+                "--fair-sched=try",
             ]
             .iter()
             .map(|x| x.to_string()),


### PR DESCRIPTION
From https://valgrind.org/docs/manual/manual-core.html#manual-core.pthreads:

> The fairness of the futex based locking produces better reproducibility of thread scheduling for different executions of a multithreaded application. 

I'm not sure whether you have tried or this is helpful to codspeed.