### PR TITLE
feat: add pre- and post-benchmark scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "sysinfo",
  "temp-env",
  "tempfile",
+ "test-with",
  "tokio",
  "tokio-tar",
  "url",
@@ -1541,6 +1542,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2175,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-with"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb2a43a245ab793321d71ff9f2be21785999c9aa5b2ea93dc507e97572be843"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ procfs = "0.17.0"
 [dev-dependencies]
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 insta = { version = "1.29.0", features = ["json", "redactions"] }
-
+test-with = { version = "0.15", default-features = false, features = [] }
 
 [workspace.metadata.release]
 sign-tag = true

--- a/src/run/runner/valgrind/helpers/venv_compat.rs
+++ b/src/run/runner/valgrind/helpers/venv_compat.rs
@@ -51,6 +51,8 @@ pub fn symlink_libpython(cwd: Option<&String>) -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
+    // Only run in Github Actions, to ensure python is dynamically linked.
+    #[test_with::env(GITHUB_ACTIONS)]
     #[test]
     fn test_venv_compat_no_crash() {
         assert!(symlink_libpython(None).is_ok());

--- a/src/run/runner/wall_time/perf/mod.rs
+++ b/src/run/runner/wall_time/perf/mod.rs
@@ -31,6 +31,52 @@ pub mod unwind_data;
 
 const PERF_DATA_PREFIX: &str = "perf.data.";
 
+struct EnvGuard;
+
+impl EnvGuard {
+    fn execute_script_from_env(script_env_var: &str) -> anyhow::Result<()> {
+        let Ok(script_path) = std::env::var(script_env_var) else {
+            debug!("Couldn't find {script_env_var}, skipping script execution");
+            return Ok(());
+        };
+
+        if script_path.is_empty() {
+            return Ok(());
+        }
+
+        let path = std::path::Path::new(&script_path);
+        if !path.exists() || !path.is_file() {
+            warn!("Script not found or not a file: {}", script_path);
+            return Ok(());
+        }
+
+        let output = Command::new("bash").args([&script_path]).output()?;
+        if !output.status.success() {
+            info!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            error!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            bail!("Failed to execute script: {}", script_path);
+        }
+
+        Ok(())
+    }
+
+    pub fn setup() -> Self {
+        if let Err(e) = Self::execute_script_from_env("CODSPEED_PRE_STARTUP_SCRIPT") {
+            warn!("Failed to execute pre-startup script: {}", e);
+            println!("asdf: {e}");
+        }
+        Self
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Err(e) = Self::execute_script_from_env("CODSPEED_POST_CLEANUP_SCRIPT") {
+            warn!("Failed to execute post-cleanup script: {}", e);
+        }
+    }
+}
+
 pub struct PerfRunner {
     perf_dir: TempDir,
     benchmark_data: OnceCell<BenchmarkData>,
@@ -126,7 +172,11 @@ impl PerfRunner {
 
             Ok(())
         };
-        run_command_with_log_pipe_and_callback(cmd, on_process_started).await
+
+        {
+            let _guard = EnvGuard::setup();
+            run_command_with_log_pipe_and_callback(cmd, on_process_started).await
+        }
     }
 
     pub async fn save_files_to(&self, profile_folder: &PathBuf) -> anyhow::Result<()> {
@@ -387,5 +437,84 @@ impl BenchmarkData {
 
     pub fn bench_count(&self) -> usize {
         self.bench_order_by_pid.values().map(|v| v.len()).sum()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use std::{
+        io::{Read, Write},
+        os::unix::fs::PermissionsExt,
+    };
+
+    fn with_env<F>(vars: &[(&str, &str)], mut f: F)
+    where
+        F: FnMut(),
+    {
+        let original_vars: Vec<(&str, std::result::Result<String, std::env::VarError>)> =
+            vars.iter().map(|(k, _)| (*k, std::env::var(*k))).collect();
+
+        for (k, v) in vars {
+            std::env::set_var(k, v);
+        }
+
+        f();
+
+        for (k, v) in original_vars {
+            if let Ok(val) = v {
+                std::env::set_var(k, val);
+            } else {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[test]
+    fn test_env_guard_no_crash() {
+        fn create_run_script(content: &str) -> anyhow::Result<NamedTempFile> {
+            let rwx = std::fs::Permissions::from_mode(0o777);
+            let mut script_file = tempfile::Builder::new()
+                .suffix(".sh")
+                .permissions(rwx)
+                .keep(true)
+                .tempfile()?;
+            script_file.write_all(content.as_bytes())?;
+
+            Ok(script_file)
+        }
+
+        let mut tmp_dst = tempfile::NamedTempFile::new().unwrap();
+
+        let pre_script = create_run_script(&format!(
+            "#!/usr/bin/env bash\necho \"pre\" >> {}",
+            tmp_dst.path().display()
+        ))
+        .unwrap();
+        let post_script = create_run_script(&format!(
+            "#!/usr/bin/env bash\necho \"post\" >> {}",
+            tmp_dst.path().display()
+        ))
+        .unwrap();
+
+        let env_vars = [
+            (
+                "CODSPEED_PRE_STARTUP_SCRIPT",
+                &*pre_script.path().to_string_lossy(),
+            ),
+            (
+                "CODSPEED_POST_CLEANUP_SCRIPT",
+                &post_script.path().to_string_lossy(),
+            ),
+        ];
+
+        with_env(&env_vars, || {
+            let _guard = EnvGuard::setup();
+        });
+
+        let mut result = String::new();
+        tmp_dst.read_to_string(&mut result).unwrap();
+        assert_eq!(result, "pre\npost\n");
     }
 }


### PR DESCRIPTION
This allows us to run custom logic on the macro runner (e.g. set core isolation) without having all of that logic inside the runner.