### PR TITLE
Cod 1248 address warnings in benchmark steps of GitHub actions

### DIFF
--- a/src/run/runner/valgrind/executor.rs
+++ b/src/run/runner/valgrind/executor.rs
@@ -21,7 +21,8 @@ impl Executor for ValgrindExecutor {
         install_valgrind(system_info).await?;
 
         if let Err(error) = venv_compat::symlink_libpython(None) {
-            error!("Failed to symlink libpython: {error}");
+            warn!("Failed to symlink libpython");
+            debug!("Script error: {error}");
         }
 
         Ok(())

--- a/src/run/runner/valgrind/executor.rs
+++ b/src/run/runner/valgrind/executor.rs
@@ -22,8 +22,6 @@ impl Executor for ValgrindExecutor {
 
         if let Err(error) = venv_compat::symlink_libpython(None) {
             error!("Failed to symlink libpython: {error}");
-        } else {
-            info!("Successfully added symlink for libpython in the venv");
         }
 
         Ok(())

--- a/src/run/runner/valgrind/helpers/venv_compat.sh
+++ b/src/run/runner/valgrind/helpers/venv_compat.sh
@@ -6,7 +6,7 @@ function add_symlink() {
     system_python="$(readlink -f "$venv_python")"
     if [ -z "$system_python" ]; then
         echo "Error: Failed to resolve real path for $venv_python" >&2
-        return 1
+        return 0
     fi
 
     system_path="$(dirname $(dirname "$system_python"))"
@@ -17,7 +17,7 @@ function add_symlink() {
     libpython_name="$(ldd "$venv_python" 2>/dev/null | grep -o -m1 'libpython[^[:space:]]*' || true)"
     if [ -z "$libpython_name" ]; then
         echo "Error: exact libpython name not found in $(ldd $venv_python)" >&2
-        return 1
+        return 0
     fi
     echo "Found linked libpython: $libpython_name"
 


### PR DESCRIPTION
This is done so that we don't pollute the logs of GitHub Actions. Also split the warning and script error, so that we don't accidentally create multiple error annotations: 
<img width="1108" height="1015" alt="image" src="https://github.com/user-attachments/assets/4be5c494-1d23-4c55-89a3-a4044078a327" />
