### PR TITLE
Prototype macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           extra_args: --all-files
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
           extra_args: --all-files
 
   tests:
-    runs-on: [ubuntu-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,13 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+targets = [
+    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-musl",
+    # macOS targets (Apple Silicon and Intel)
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+]
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # Which actions to run on pull requests
@@ -108,3 +114,6 @@ install-updater = false
 
 [workspace.metadata.dist.github-custom-runners]
 aarch64-unknown-linux-musl = "buildjet-2vcpu-ubuntu-2204-arm"
+# Use GitHub-hosted macOS runners for apple-darwin targets by default
+aarch64-apple-darwin = "macos-latest"
+x86_64-apple-darwin = "macos-latest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ installers = ["shell"]
 targets = [
     "aarch64-unknown-linux-musl",
     "x86_64-unknown-linux-musl",
-    # macOS targets (Apple Silicon and Intel)
+    # macOS targets (Apple Silicon)
     "aarch64-apple-darwin",
 ]
 # The archive format to use for non-windows builds (defaults .tar.xz)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ targets = [
     "x86_64-unknown-linux-musl",
     # macOS targets (Apple Silicon and Intel)
     "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
 ]
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
@@ -116,4 +115,4 @@ install-updater = false
 aarch64-unknown-linux-musl = "buildjet-2vcpu-ubuntu-2204-arm"
 # Use GitHub-hosted macOS runners for apple-darwin targets by default
 aarch64-apple-darwin = "macos-latest"
-x86_64-apple-darwin = "macos-latest"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,3 @@ install-updater = false
 aarch64-unknown-linux-musl = "buildjet-2vcpu-ubuntu-2204-arm"
 # Use GitHub-hosted macOS runners for apple-darwin targets by default
 aarch64-apple-darwin = "macos-latest"
-

--- a/scripts/simple-installer.sh
+++ b/scripts/simple-installer.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Simple installer for codspeed-runner
+# This script clones the repository (or uses the current directory), builds the
+# `codspeed` binary with cargo in release mode, and installs it to the target
+# directory (default: /usr/local/bin). It intentionally avoids cargo-dist and
+# the GitHub release flow so you can build and install locally or from CI.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/jzombie/codspeed-runner.git"
+REF="main"
+INSTALL_DIR="/usr/local/bin"
+TMP_DIR=""
+NO_RUSTUP="false"
+QUIET="false"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--repo <git-url>] [--ref <branch-or-tag>] [--install-dir <path>] [--no-rustup] [--quiet]
+
+Options:
+  --repo        Git repository URL (default: ${REPO_URL})
+  --ref         Git ref to checkout (branch, tag, or commit). Default: ${REF}
+  --install-dir Where to install the built binary. Default: ${INSTALL_DIR}
+  --no-rustup   Do not attempt to install rustup if cargo is missing
+  --quiet       Minimize output
+  -h, --help    Show this help message
+
+Example:
+  curl -fsSL https://example.com/codspeed-runner-installer.sh | bash -s -- --ref feature/my-branch
+
+This script will clone the repository to a temporary directory, build the
+`codspeed` binary with `cargo build --release`, and copy it to
+${INSTALL_DIR}. Sudo may be used to write to the install directory.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      REPO_URL="$2"; shift 2;;
+    --ref)
+      REF="$2"; shift 2;;
+    --install-dir)
+      INSTALL_DIR="$2"; shift 2;;
+    --no-rustup)
+      NO_RUSTUP="true"; shift 1;;
+    --quiet)
+      QUIET="true"; shift 1;;
+    -h|--help)
+      usage; exit 0;;
+    --)
+      shift; break;;
+    *)
+      echo "Unknown argument: $1" >&2; usage; exit 1;;
+  esac
+done
+
+log() {
+  if [ "$QUIET" != "true" ]; then
+    echo "$@"
+  fi
+}
+
+fail() {
+  echo "Error: $@" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+check_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+ensure_rust() {
+  if check_command cargo; then
+    log "Found cargo"
+    return 0
+  fi
+
+  if [ "$NO_RUSTUP" = "true" ]; then
+    fail "cargo is not installed and --no-rustup was passed. Install Rust toolchain first.";
+  fi
+
+  log "Rust toolchain not found. Installing rustup (non-interactive)..."
+  # Install rustup non-interactively
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y || fail "failed to install rustup"
+  export PATH="$HOME/.cargo/bin:$PATH"
+  check_command cargo || fail "cargo still not available after rustup install"
+}
+
+main() {
+  ensure_rust
+
+  # Create temp dir
+  TMP_DIR=$(mktemp -d -t codspeed-installer-XXXX)
+  log "Using temporary directory: $TMP_DIR"
+
+  # Clone the requested ref
+  log "Cloning ${REPO_URL} (ref: ${REF})..."
+  git clone --depth 1 --branch "$REF" "$REPO_URL" "$TMP_DIR" || {
+    # Try cloning default branch and then checking out ref (for commit-ish refs)
+    log "Shallow clone failed for ref $REF, attempting full clone and checkout"
+    rm -rf "$TMP_DIR"
+    TMP_DIR=$(mktemp -d -t codspeed-installer-XXXX)
+    git clone "$REPO_URL" "$TMP_DIR" || fail "failed to clone repo"
+    (cd "$TMP_DIR" && git fetch --all --tags && git checkout "$REF") || fail "failed to checkout ref $REF"
+  }
+
+  # Build
+  log "Building codspeed (release)..."
+  (cd "$TMP_DIR" && cargo build --release) || fail "cargo build failed"
+
+  # Locate built binary
+  BIN_PATH="$TMP_DIR/target/release/codspeed"
+  if [ ! -x "$BIN_PATH" ]; then
+    fail "Built binary not found at $BIN_PATH"
+  fi
+
+  # Ensure install dir exists
+  if [ ! -d "$INSTALL_DIR" ]; then
+    log "Creating install directory $INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR" || fail "failed to create install dir"
+  fi
+
+  # Copy binary (use sudo if required)
+  DEST="$INSTALL_DIR/codspeed"
+  if [ -w "$INSTALL_DIR" ]; then
+    cp "$BIN_PATH" "$DEST" || fail "failed to copy binary to $DEST"
+  else
+    log "Installing to $DEST with sudo"
+    sudo cp "$BIN_PATH" "$DEST" || fail "sudo copy failed"
+  fi
+
+  log "Installed codspeed to $DEST"
+  log "Run 'codspeed --help' to verify"
+}
+
+main "$@"

--- a/src/run/check_system.rs
+++ b/src/run/check_system.rs
@@ -135,7 +135,14 @@ pub fn check_system(system_info: &SystemInfo) -> Result<()> {
         return Ok(());
     }
 
-    match system_info.arch.as_str() {
+    // Normalize common architecture strings (macOS reports `arm64` on Apple
+    // Silicon; treat it as `aarch64` which the rest of the codebase expects).
+    let arch = match system_info.arch.as_str() {
+        "arm64" => "aarch64",
+        other => other,
+    };
+
+    match arch {
         "x86_64" | "aarch64" => {
             warn!(
                 "Unofficially supported system: {} {}. Continuing with best effort support.",

--- a/src/run/run_environment/github_actions/provider.rs
+++ b/src/run/run_environment/github_actions/provider.rs
@@ -90,22 +90,7 @@ impl TryFrom<&Config> for GitHubActionsProvider {
                 path.push("");
                 path.to_string_lossy().to_string()
             }
-            None => {
-                let workspace = std::env::var("GITHUB_WORKSPACE").ok().and_then(|p| {
-                    let mut path = std::path::PathBuf::from(p);
-                    if path.is_dir() {
-                        path.push("");
-                        Some(path)
-                    } else {
-                        None
-                    }
-                });
-
-                match workspace {
-                    Some(path) => path.to_string_lossy().to_string(),
-                    None => format!("/home/runner/work/{repository}/{repository}/"),
-                }
-            }
+            None => format!("/home/runner/work/{repository}/{repository}/"),
         };
 
         Ok(Self {

--- a/src/run/run_environment/github_actions/provider.rs
+++ b/src/run/run_environment/github_actions/provider.rs
@@ -90,7 +90,22 @@ impl TryFrom<&Config> for GitHubActionsProvider {
                 path.push("");
                 path.to_string_lossy().to_string()
             }
-            None => format!("/home/runner/work/{repository}/{repository}/"),
+            None => {
+                let workspace = std::env::var("GITHUB_WORKSPACE").ok().and_then(|p| {
+                    let mut path = std::path::PathBuf::from(p);
+                    if path.is_dir() {
+                        path.push("");
+                        Some(path)
+                    } else {
+                        None
+                    }
+                });
+
+                match workspace {
+                    Some(path) => path.to_string_lossy().to_string(),
+                    None => format!("/home/runner/work/{repository}/{repository}/"),
+                }
+            }
         };
 
         Ok(Self {

--- a/src/run/runner/wall_time/executor.rs
+++ b/src/run/runner/wall_time/executor.rs
@@ -21,7 +21,7 @@ fn shell_quote(value: &str) -> String {
     if value.is_empty() {
         "''".to_string()
     } else if !value.contains('\'') {
-        format!("'{}'", value)
+        format!("'{value}'")
     } else {
         let mut quoted = String::with_capacity(value.len() + 2);
         quoted.push('\'');

--- a/src/run/runner/wall_time/executor.rs
+++ b/src/run/runner/wall_time/executor.rs
@@ -365,16 +365,6 @@ impl WallTimeExecutor {
         effective_cwd: &Path,
         target_root: &Path,
     ) -> Result<()> {
-        // When running unit tests on macOS we synthesize the benchmark command but do not
-        // produce CodSpeed walltime artifacts. Invoking `cargo codspeed build` from tests would
-        // fail (no project state, no benches) and make the suite extremely slow, so we skip the
-        // rebuild in that scenario only. The production binary still performs the rebuild check on
-        // macOS because the guard is behind `cfg!(test)`.
-        if cfg!(all(test, target_os = "macos")) {
-            trace!("Skipping walltime rebuild during macOS tests");
-            return Ok(());
-        }
-
         let codspeed_dir = target_root.join("codspeed");
         let walltime_dir = codspeed_dir.join("walltime");
         if has_any_files(&walltime_dir)? {

--- a/src/run/runner/wall_time/executor.rs
+++ b/src/run/runner/wall_time/executor.rs
@@ -177,10 +177,12 @@ impl Executor for WallTimeExecutor {
         run_data: &RunData,
         _mongo_tracer: &Option<MongoTracer>,
     ) -> Result<()> {
-        // Note: (jzombie) Workaround for asking for `sudo password` on macOS
+        // Note: (jzombie) Workaround for asking for `sudo password` on macOS.
         // Only use sudo when perf is enabled and available; otherwise run the
         // benchmark directly to avoid prompting for passwords on CI (macOS
         // runners, etc.).
+        // TODO: There is also a `run_with_sudo` in `setup.rs` that might be a
+        // better way to approach this
         let use_sudo = self.perf.is_some() && config.enable_perf;
         let mut cmd = if use_sudo {
             Command::new("sudo")

--- a/src/run/runner/wall_time/executor.rs
+++ b/src/run/runner/wall_time/executor.rs
@@ -149,7 +149,36 @@ impl WallTimeExecutor {
 
         let combined_env = if use_systemd {
             let system_env = get_exported_system_env()?;
-            format!("{system_env}\n{base_injected_env}\n{path_env}")
+            // Sanitize system `export` output to only include valid shell identifiers.
+            // Some environments (editor integrations, IDEs) can inject nonsense names
+            // which `bash` rejects when `source`-ing the env file. Filter them out.
+            let mut sanitized = String::new();
+            for line in system_env.lines() {
+                // strip leading `declare -x ` if present (bash `export` prints that form)
+                let mut l = line.trim();
+                if let Some(rest) = l.strip_prefix("declare -x ") {
+                    l = rest.trim();
+                }
+                if let Some(rest) = l.strip_prefix("export ") {
+                    l = rest.trim();
+                }
+
+                // left of '=' is the var name; ensure it's a valid identifier: [A-Za-z_][A-Za-z0-9_]*
+                if let Some(eq) = l.find('=') {
+                    let name = &l[..eq].trim();
+                    let mut chars = name.chars();
+                    if let Some(first) = chars.next() {
+                        if (first == '_' || first.is_ascii_alphabetic())
+                            && chars.clone().all(|c| c == '_' || c.is_ascii_alphanumeric())
+                        {
+                            sanitized.push_str(line);
+                            sanitized.push('\n');
+                        }
+                    }
+                }
+            }
+
+            format!("{sanitized}{base_injected_env}\n{path_env}")
         } else {
             format!("{base_injected_env}\n{path_env}")
         };

--- a/src/run/runner/wall_time/perf/mod.rs
+++ b/src/run/runner/wall_time/perf/mod.rs
@@ -9,6 +9,7 @@ use crate::run::runner::helpers::setup::run_with_sudo;
 use crate::run::runner::valgrind::helpers::ignored_objects_path::get_objects_path_to_ignore;
 use crate::run::runner::valgrind::helpers::perf_maps::harvest_perf_maps_for_pids;
 use crate::run::runner::wall_time::perf::jit_dump::harvest_perf_jit_for_pids;
+#[cfg(target_os = "linux")]
 use crate::run::runner::wall_time::perf::unwind_data::UnwindDataExt;
 use anyhow::Context;
 use fifo::{PerfFifo, RunnerFifo};
@@ -271,8 +272,15 @@ impl PerfRunner {
     ) -> anyhow::Result<BenchmarkData> {
         let mut bench_order_by_timestamp = Vec::<(u64, String)>::new();
         let mut bench_pids = HashSet::<pid_t>::new();
+        #[cfg(target_os = "linux")]
         let mut symbols_by_pid = HashMap::<pid_t, ProcessSymbols>::new();
+        #[cfg(not(target_os = "linux"))]
+        let symbols_by_pid = HashMap::<pid_t, ProcessSymbols>::new();
+
+        #[cfg(target_os = "linux")]
         let mut unwind_data_by_pid = HashMap::<pid_t, Vec<UnwindData>>::new();
+        #[cfg(not(target_os = "linux"))]
+        let unwind_data_by_pid = HashMap::<pid_t, Vec<UnwindData>>::new();
         let mut markers = Vec::<MarkerType>::new();
 
         let mut integration = None;

--- a/src/run/runner/wall_time/perf/perf_map.rs
+++ b/src/run/runner/wall_time/perf/perf_map.rs
@@ -31,6 +31,7 @@ pub struct ModuleSymbols {
     symbols: Vec<Symbol>,
 }
 
+#[allow(dead_code)]
 impl ModuleSymbols {
     pub fn from_symbols(symbols: Vec<Symbol>) -> Self {
         Self { symbols }
@@ -106,6 +107,7 @@ pub struct ProcessSymbols {
     modules: HashMap<PathBuf, ModuleSymbols>,
 }
 
+#[allow(dead_code)]
 impl ProcessSymbols {
     pub fn new(pid: pid_t) -> Self {
         Self {

--- a/src/run/runner/wall_time/perf/unwind_data.rs
+++ b/src/run/runner/wall_time/perf/unwind_data.rs
@@ -8,6 +8,7 @@ use object::ObjectSection;
 use runner_shared::unwind_data::UnwindData;
 use std::ops::Range;
 
+#[allow(dead_code)]
 pub trait UnwindDataExt {
     fn new(
         path_slice: &[u8],


### PR DESCRIPTION
- Must use `WallTime` for macOS
- Add macOS to test matrix (macOS tests pass)
- Still debugging Linux tests (are they just authentication errors?)
- Add [scripts/simple-installer.sh](https://github.com/CodSpeedHQ/runner/pull/124/files#diff-a42b9abac36215cc533e298a456391eb5c80834b78de1d1c9cbdfe83c282abb2) for debugging
- Resolve Clippy warnings elsewhere
- [debug; may no longer be required] `CODSPEED_PERF_ENABLED` env variable must be set to false to skip Linux perf profiler
- Docs not updated

-------

Added warning for "unofficial support" for macOS:

<img width="694" height="142" alt="Screenshot 2025-10-05 at 5 59 30 PM" src="https://github.com/user-attachments/assets/501474cb-9034-45f0-b6cc-c598104aff6d" />

-------

Benches successfully record:

<img width="1594" height="1084" alt="Screenshot 2025-10-05 at 7 32 39 PM" src="https://github.com/user-attachments/assets/6e5a2f5b-74bc-4a8d-b266-5d54266c1c99" />
