### PR TITLE
Add caching for tools installed by the runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "serde_yaml",
  "sha256",
  "shell-quote",
+ "shellexpand",
  "simplelog",
  "sysinfo",
  "temp-env",
@@ -448,6 +449,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1402,6 +1424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1753,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.8.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2105,6 +2144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb502615975ae2365825521fa1529ca7648fd03ce0b0746604e0683856ecd7e4"
 dependencies = [
  "bstr",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ memmap2 = "0.9.5"
 nix = { version = "0.29.0", features = ["fs", "time", "user"] }
 futures = "0.3.31"
 runner-shared = { path = "crates/runner-shared" }
+shellexpand = { version = "3.1.1", features = ["tilde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.17.0"

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -9,6 +9,7 @@ use instruments::mongo_tracer::{MongoTracer, install_mongodb_tracer};
 use run_environment::interfaces::{RepositoryProvider, RunEnvironment};
 use runner::get_run_data;
 use serde::Serialize;
+use std::path::Path;
 use std::path::PathBuf;
 
 pub mod check_system;
@@ -176,6 +177,7 @@ pub async fn run(
     args: RunArgs,
     api_client: &CodSpeedAPIClient,
     codspeed_config: &CodSpeedConfig,
+    setup_cache_dir: Option<&Path>,
 ) -> Result<()> {
     let output_json = args.message_format == Some(MessageFormat::Json);
     let mut config = Config::try_from(args)?;
@@ -202,7 +204,7 @@ pub async fn run(
 
     if !config.skip_setup {
         start_group!("Preparing the environment");
-        executor.setup(&system_info).await?;
+        executor.setup(&system_info, setup_cache_dir).await?;
         // TODO: refactor and move directly in the Instruments struct as a `setup` method
         if config.instruments.is_mongodb_enabled() {
             install_mongodb_tracer().await?;

--- a/src/run/runner/executor.rs
+++ b/src/run/runner/executor.rs
@@ -3,12 +3,17 @@ use crate::prelude::*;
 use crate::run::instruments::mongo_tracer::MongoTracer;
 use crate::run::{check_system::SystemInfo, config::Config};
 use async_trait::async_trait;
+use std::path::Path;
 
 #[async_trait(?Send)]
 pub trait Executor {
     fn name(&self) -> ExecutorName;
 
-    async fn setup(&self, _system_info: &SystemInfo) -> Result<()> {
+    async fn setup(
+        &self,
+        _system_info: &SystemInfo,
+        _setup_cache_dir: Option<&Path>,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/src/run/runner/helpers/apt.rs
+++ b/src/run/runner/helpers/apt.rs
@@ -1,0 +1,188 @@
+use super::run_with_sudo::run_with_sudo;
+use crate::prelude::*;
+use crate::run::check_system::SystemInfo;
+use std::path::Path;
+use std::process::Command;
+
+fn is_system_compatible(system_info: &SystemInfo) -> bool {
+    system_info.os == "ubuntu" || system_info.os == "debian"
+}
+
+/// Installs packages with caching support.
+///
+/// This function provides a common pattern for installing tools on Ubuntu/Debian systems
+/// with automatic caching to speed up subsequent installations (e.g., in CI environments).
+///
+/// # Arguments
+///
+/// * `system_info` - System information to determine compatibility
+/// * `setup_cache_dir` - Optional directory to restore from/save to cache
+/// * `is_installed` - Function that checks if the tool is already installed
+/// * `install_packages` - Async closure that:
+///   1. Performs the installation (e.g., downloads .deb files, calls `apt::install`)
+///   2. Returns a Vec of package names that should be cached via `dpkg -L`
+///
+/// # Flow
+///
+/// 1. Check if already installed - if yes, skip everything
+/// 2. Try to restore from cache (if cache_dir provided)
+/// 3. Check again if installed - if yes, we're done
+/// 4. Run the install closure to install and get package names
+/// 5. Save installed packages to cache (if cache_dir provided)
+///
+/// # Example
+///
+/// ```rust,ignore
+/// apt::install_cached(
+///     system_info,
+///     setup_cache_dir,
+///     || Command::new("which").arg("perf").status().is_ok(),
+///     || async {
+///         let packages = vec!["linux-tools-common".to_string()];
+///         let refs: Vec<&str> = packages.iter().map(|s| s.as_str()).collect();
+///         apt::install(system_info, &refs)?;
+///         Ok(packages) // Return package names for caching
+///     },
+/// ).await?;
+/// ```
+pub async fn install_cached<F, I, Fut>(
+    system_info: &SystemInfo,
+    setup_cache_dir: Option<&Path>,
+    is_installed: F,
+    install_packages: I,
+) -> Result<()>
+where
+    F: Fn() -> bool,
+    I: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<String>>>,
+{
+    if is_installed() {
+        info!("Tool already installed, skipping installation");
+        return Ok(());
+    }
+
+    // Try to restore from cache first
+    if let Some(cache_dir) = setup_cache_dir {
+        restore_from_cache(system_info, cache_dir)?;
+
+        if is_installed() {
+            info!("Tool has been successfully restored from cache");
+            return Ok(());
+        }
+    }
+
+    // Install and get the package names for caching
+    let cache_packages = install_packages().await?;
+
+    info!("Installation completed successfully");
+
+    // Save to cache after successful installation
+    if let Some(cache_dir) = setup_cache_dir {
+        let cache_refs: Vec<&str> = cache_packages.iter().map(|s| s.as_str()).collect();
+        save_to_cache(system_info, cache_dir, &cache_refs)?;
+    }
+
+    Ok(())
+}
+
+pub fn install(system_info: &SystemInfo, packages: &[&str]) -> Result<()> {
+    if !is_system_compatible(system_info) {
+        bail!(
+            "Package installation is not supported on this system, please install necessary packages manually"
+        );
+    }
+
+    debug!("Installing packages: {packages:?}");
+
+    run_with_sudo(&["apt-get", "update"])?;
+    let mut install_cmd = vec!["apt-get", "install", "-y", "--allow-downgrades"];
+    install_cmd.extend_from_slice(packages);
+    run_with_sudo(&install_cmd)?;
+
+    debug!("Packages installed successfully");
+    Ok(())
+}
+
+/// Restore cached tools from the cache directory to the root filesystem
+fn restore_from_cache(system_info: &SystemInfo, cache_dir: &Path) -> Result<()> {
+    if !is_system_compatible(system_info) {
+        warn!("Cache restore is not supported on this system, skipping");
+        return Ok(());
+    }
+
+    if !cache_dir.exists() {
+        debug!("Cache directory does not exist: {}", cache_dir.display());
+        return Ok(());
+    }
+
+    // Check if the directory has any contents
+    let has_contents = std::fs::read_dir(cache_dir)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false);
+
+    if !has_contents {
+        debug!("Cache directory is empty: {}", cache_dir.display());
+        return Ok(());
+    }
+
+    debug!(
+        "Restoring tools from cache directory: {}",
+        cache_dir.display()
+    );
+
+    // Use bash to properly handle glob expansion
+    let cache_dir_str = cache_dir
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid cache directory path"))?;
+
+    let copy_cmd = format!("cp -r {cache_dir_str}/* /");
+
+    run_with_sudo(&["bash", "-c", &copy_cmd])?;
+
+    debug!("Cache restored successfully");
+    Ok(())
+}
+
+/// Save installed packages to the cache directory
+fn save_to_cache(system_info: &SystemInfo, cache_dir: &Path, packages: &[&str]) -> Result<()> {
+    if !is_system_compatible(system_info) {
+        warn!("Caching of installed package is not supported on this system, skipping");
+        return Ok(());
+    }
+
+    debug!(
+        "Saving installed packages to cache: {}",
+        cache_dir.display()
+    );
+
+    // Create cache directory if it doesn't exist
+    std::fs::create_dir_all(cache_dir).context("Failed to create cache directory")?;
+
+    let cache_dir_str = cache_dir
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid cache directory path"))?;
+
+    // Logic taken from https://stackoverflow.com/a/59277514
+    // This shell command lists all the files outputted by the given packages and copy them to the cache directory
+    let packages_str = packages.join(" ");
+    let shell_cmd = format!(
+        "dpkg -L {packages_str} | while IFS= read -r f; do if test -f \"$f\"; then echo \"$f\"; fi; done | xargs cp --parents --target-directory {cache_dir_str}",
+    );
+
+    debug!("Running cache save command: {shell_cmd}");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(&shell_cmd)
+        .output()
+        .context("Failed to execute cache save command")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("stderr: {stderr}");
+        bail!("Failed to save packages to cache");
+    }
+
+    debug!("Packages cached successfully");
+    Ok(())
+}

--- a/src/run/runner/helpers/mod.rs
+++ b/src/run/runner/helpers/mod.rs
@@ -1,7 +1,8 @@
+pub mod apt;
 pub mod env;
 pub mod get_bench_command;
 pub mod introspected_golang;
 pub mod introspected_nodejs;
 pub mod profile_folder;
 pub mod run_command_with_log_pipe;
-pub mod setup;
+pub mod run_with_sudo;

--- a/src/run/runner/helpers/run_with_sudo.rs
+++ b/src/run/runner/helpers/run_with_sudo.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use log::{debug, info};
 use std::process::{Command, Stdio};
 
 /// Run a command with sudo if available

--- a/src/run/runner/tests.rs
+++ b/src/run/runner/tests.rs
@@ -139,7 +139,7 @@ mod valgrind {
             .get_or_init(|| async {
                 let executor = ValgrindExecutor;
                 let system_info = SystemInfo::new().unwrap();
-                executor.setup(&system_info).await.unwrap();
+                executor.setup(&system_info, None).await.unwrap();
                 executor
             })
             .await
@@ -196,7 +196,7 @@ mod walltime {
             .get_or_init(|| async {
                 let executor = WallTimeExecutor::new();
                 let system_info = SystemInfo::new().unwrap();
-                executor.setup(&system_info).await.unwrap();
+                executor.setup(&system_info, None).await.unwrap();
             })
             .await;
 

--- a/src/run/runner/valgrind/executor.rs
+++ b/src/run/runner/valgrind/executor.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::path::Path;
 
 use crate::prelude::*;
 use crate::run::instruments::mongo_tracer::MongoTracer;
@@ -17,8 +18,8 @@ impl Executor for ValgrindExecutor {
         ExecutorName::Valgrind
     }
 
-    async fn setup(&self, system_info: &SystemInfo) -> Result<()> {
-        install_valgrind(system_info).await?;
+    async fn setup(&self, system_info: &SystemInfo, setup_cache_dir: Option<&Path>) -> Result<()> {
+        install_valgrind(system_info, setup_cache_dir).await?;
 
         if let Err(error) = venv_compat::symlink_libpython(None) {
             warn!("Failed to symlink libpython");

--- a/src/run/runner/wall_time/executor.rs
+++ b/src/run/runner/wall_time/executor.rs
@@ -13,7 +13,8 @@ use crate::run::{check_system::SystemInfo, config::Config};
 use async_trait::async_trait;
 use std::fs::canonicalize;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 use tempfile::NamedTempFile;
 
@@ -162,9 +163,9 @@ impl Executor for WallTimeExecutor {
         ExecutorName::WallTime
     }
 
-    async fn setup(&self, _system_info: &SystemInfo) -> Result<()> {
+    async fn setup(&self, system_info: &SystemInfo, setup_cache_dir: Option<&Path>) -> Result<()> {
         if self.perf.is_some() {
-            PerfRunner::setup_environment()?;
+            PerfRunner::setup_environment(system_info, setup_cache_dir).await?;
         }
 
         Ok(())

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,8 +1,9 @@
 use crate::prelude::*;
 use crate::run::check_system::SystemInfo;
 use crate::run::runner::get_all_executors;
+use std::path::Path;
 
-pub async fn setup() -> Result<()> {
+pub async fn setup(setup_cache_dir: Option<&Path>) -> Result<()> {
     let system_info = SystemInfo::new()?;
     let executors = get_all_executors();
     start_group!("Setting up the environment for all executors");
@@ -11,7 +12,7 @@ pub async fn setup() -> Result<()> {
             "Setting up the environment for the executor: {}",
             executor.name().to_string()
         );
-        executor.setup(&system_info).await?;
+        executor.setup(&system_info, setup_cache_dir).await?;
     }
     info!("Environment setup completed");
     end_group!();


### PR DESCRIPTION
- For now, limited to apt based system, though mostly tested on ubuntu
- Set the path to the desired cache location to `CODSPEED_SETUP_CACHE_DIR` env var or --setup-cache-dir to enable
- Any tool installed will have the content of its package saved to this directory
- Before installing any missing tool, first attempt to restore from cache before using apt

This is aimed to be used alongside CI cache to speed up jobs

Fixes #121 