### PR TITLE
feat(run): support simulation for free-threaded python

### DIFF
--- a/src/run/runner/valgrind/helpers/mod.rs
+++ b/src/run/runner/valgrind/helpers/mod.rs
@@ -1,3 +1,4 @@
 pub mod ignored_objects_path;
 pub mod perf_maps;
+pub mod python;
 pub mod venv_compat;

--- a/src/run/runner/valgrind/helpers/python.rs
+++ b/src/run/runner/valgrind/helpers/python.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+/// Checks if the Python interpreter supports free-threaded mode.
+/// Returns true if Python is free-threaded (GIL disabled), false otherwise.
+pub fn is_free_threaded_python() -> bool {
+    // Use sysconfig.get_config_var("Py_GIL_DISABLED") as recommended by Python docs at https://docs.python.org/3/howto/free-threading-python.html#identifying-free-threaded-python
+    let output = Command::new("python")
+        .args([
+            "-c",
+            "import sysconfig; print(sysconfig.get_config_var('Py_GIL_DISABLED') or 0)",
+        ])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout.trim() == "1"
+        }
+        _ => false, // If Python is not available or command fails, assume not free-threaded
+    }
+}


### PR DESCRIPTION
Remove PYTHONMALLOC=malloc which is unsupported for free-threaded builds

Needed for https://github.com/CodSpeedHQ/pytest-codspeed/pull/96 to land
