### PR TITLE
fix: do not cat stdout from command to pipe.data

### DIFF
--- a/src/executor/wall_time/perf/mod.rs
+++ b/src/executor/wall_time/perf/mod.rs
@@ -172,11 +172,16 @@ impl PerfRunner {
         // Output the perf data to the profile folder
         let perf_data_file_path = self.get_perf_file_path(profile_folder);
 
-        let raw_command = format!(
-            "set -o pipefail && {} | cat > {}",
-            &cmd_builder.as_command_line(),
-            perf_data_file_path.to_string_lossy()
-        );
+        let raw_command = if self.output_pipedata {
+            format!(
+                "set -o pipefail && {} | cat > {}",
+                &cmd_builder.as_command_line(),
+                perf_data_file_path.to_string_lossy()
+            )
+        } else {
+            cmd_builder.as_command_line()
+        };
+
         let mut wrapped_builder = CommandBuilder::new("bash");
         wrapped_builder.args(["-c", &raw_command]);
 


### PR DESCRIPTION
The real long term solution is to no longer use pipe.data now that the linux-perf-data fork for streamable file format is public.