### PR TITLE
Override release_command from cargo dist to prevent automatic latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,19 @@ jobs:
           # If we're editing a release in place, we need to upload things ahead of time
           gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*
 
-          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
+          # ⚠️ MANUAL EDIT
+          # Replacement for the generated line
+          # gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
+          #
+          # Customize gh release edit call to prevent gh release edit --draft=false from marking the release as latest
+          # https://github.com/axodotdev/cargo-dist/issues/2244
+          export RELEASE_ID=$(gh api repos/{owner}/{repo}/releases --jq '.[] | select(.tag_name == "${{ needs.plan.outputs.tag }}") | .id')
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Error: Could not find release ID for tag"
+            exit 1
+          fi
+          gh api repos/{owner}/{repo}/releases/$RELEASE_ID --method PATCH -f draft=false
+          # ⚠️ END OF MANUAL EDIT
 
   announce:
     needs:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,6 +27,11 @@ precise-builds = true
 create-release = false
 # Use the stage just after plan because we need its output to create the draft release
 local-artifacts-jobs = ["./create-draft-release"]
+# Uncomment this to rerun `dist generate`
+# ⚠️ This will overwrite any manual changes to generated files, make sure to re-apply them if they're still relevant
+# We need this to prevent gh release edit from marking any release as latest, but cargo-dist does not support that customizing this yet
+# https://github.com/axodotdev/cargo-dist/issues/2244
+allow-dirty = ["ci"]
 
 [dist.github-custom-runners]
 aarch64-unknown-linux-musl = "buildjet-2vcpu-ubuntu-2204-arm"


### PR DESCRIPTION
Testing showed that

```
gh release create v1.0.1 --draft
gh release edit v1.0.1 --draft=false
```
will automatically mark the release as latest
this is also true if we explicitly do `gh release edit v1.0.1 --draft=false --latest=false`

We have two issues here
1. Cargo dist does not allow customizing the release command, https://github.com/axodotdev/cargo-dist/issues/2244
2. We need to use `gh api` in order to prevent `gh release edit` trying to me too smart for its own good.

The release is then marked as latest as part of the post-announce workflow if we have released a non pre release runner version.


Tested here: https://github.com/CodSpeedHQ/runner/actions/runs/20745672268/job/59562574430#step:10:8
The alpha release is cleaned up already, but I can do further testing if necessary