### PR TITLE
chore: bump memtrack version

### DIFF
--- a/src/executor/memory/executor.rs
+++ b/src/executor/memory/executor.rs
@@ -25,7 +25,7 @@ use tempfile::NamedTempFile;
 use tokio::time::{Duration, timeout};
 
 const MEMTRACK_COMMAND: &str = "codspeed-memtrack";
-const MEMTRACK_CODSPEED_VERSION: &str = "1.0.0";
+const MEMTRACK_CODSPEED_VERSION: &str = "1.1.0";
 
 pub struct MemoryExecutor;
 


### PR DESCRIPTION
Latest memtrack version has been validated on staging, so we can bump it and ship it in the next runner release