### PR TITLE
fix: memtrack artifact emptiness check

### DIFF
--- a/src/executor/memory/executor.rs
+++ b/src/executor/memory/executor.rs
@@ -128,8 +128,8 @@ impl Executor for MemoryExecutor {
                     .to_string_lossy()
                     .contains(MemtrackArtifact::name())
             })
-            // Filter empty files:
-            .filter(|entry| entry.metadata().map(|m| m.len() == 0).unwrap_or_default())
+            .flat_map(|f| std::fs::File::open(f.path()))
+            .filter(|file| !MemtrackArtifact::is_empty(file))
             .collect();
         if files.is_empty() {
             bail!(


### PR DESCRIPTION
The zstd compressed file will never be empty on disk, so we need to check the contents.

---

Tested on `codspeed-go`: 
```
ok      example 9.638s
[INFO  codspeed_go_runner] Results written to "/tmp/profile.ZKnRO854Mi.out/results/117605.json"
[DEBUG codspeed_memtrack] Command exited with status: exit status: 0
[DEBUG codspeed_memtrack] Waiting for the drain thread to finish
[DEBUG codspeed_memtrack] Waiting for the writer thread to finish
[INFO  codspeed_memtrack] Wrote 0 memtrack events to disk
[DEBUG::runner_shared::artifacts] Saved ExecutionTimestamps result to "/tmp/profile.ZKnRO854Mi.out/results"
[DEBUG::codspeed::executor::memory::executor] cmd exit status: ExitStatus(unix_wait_status(0))

►►► Tearing down environment 
Error: No memtrack artifact files found. Does the integration support memory profiling?
```