### PR TITLE
feat: skip upload if `--allow-empty` is set and no results were produced

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -71,6 +71,13 @@ pub fn get_all_executors() -> Vec<Box<dyn Executor>> {
     ]
 }
 
+pub struct ExecutorTeardownResult {
+    /// Whether the executor has produced results
+    /// Normally, the executor should fail if it does not produce results
+    /// Unless `allow_empty` option is set
+    has_results: bool,
+}
+
 #[async_trait(?Send)]
 pub trait Executor {
     fn name(&self) -> ExecutorName;
@@ -91,7 +98,10 @@ pub trait Executor {
         mongo_tracer: &Option<MongoTracer>,
     ) -> Result<()>;
 
-    async fn teardown(&self, execution_context: &ExecutionContext) -> Result<()>;
+    async fn teardown(
+        &self,
+        execution_context: &ExecutionContext,
+    ) -> Result<ExecutorTeardownResult>;
 }
 
 /// Execute benchmarks with the given configuration
@@ -119,6 +129,8 @@ where
         end_group!();
     }
 
+    let mut has_results = false;
+
     if !execution_context.config.skip_run {
         start_opened_group!("Running the benchmarks");
 
@@ -141,7 +153,8 @@ where
         }
         end_group!();
         start_opened_group!("Tearing down environment");
-        executor.teardown(execution_context).await?;
+        let teardown_result = executor.teardown(execution_context).await?;
+        has_results = teardown_result.has_results;
 
         execution_context
             .logger
@@ -153,7 +166,7 @@ where
     };
 
     // Handle upload and polling
-    if !execution_context.config.skip_upload {
+    if has_results && !execution_context.config.skip_upload {
         if !execution_context.is_local() {
             // If relevant, set the OIDC token for authentication
             // Note: OIDC tokens can expire quickly, so we set it just before the upload

--- a/src/executor/valgrind/executor.rs
+++ b/src/executor/valgrind/executor.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use std::path::Path;
 
-use crate::executor::Executor;
 use crate::executor::{ExecutionContext, ExecutorName};
+use crate::executor::{Executor, ExecutorTeardownResult};
 use crate::instruments::mongo_tracer::MongoTracer;
 use crate::prelude::*;
 use crate::run::check_system::SystemInfo;
@@ -45,7 +45,10 @@ impl Executor for ValgrindExecutor {
         Ok(())
     }
 
-    async fn teardown(&self, execution_context: &ExecutionContext) -> Result<()> {
+    async fn teardown(
+        &self,
+        execution_context: &ExecutionContext,
+    ) -> Result<ExecutorTeardownResult> {
         harvest_perf_maps(&execution_context.profile_folder).await?;
 
         // No matter the command in input, at this point valgrind will have been run and have produced output files.
@@ -55,6 +58,6 @@ impl Executor for ValgrindExecutor {
         // A comprehensive message will be sent to the user if no benchmarks are detected,
         // even if it's later in the process than technically possible.
 
-        Ok(())
+        Ok(ExecutorTeardownResult { has_results: true })
     }
 }

--- a/src/executor/wall_time/executor.rs
+++ b/src/executor/wall_time/executor.rs
@@ -2,6 +2,7 @@ use super::helpers::validate_walltime_results;
 use super::perf::PerfRunner;
 use crate::executor::Config;
 use crate::executor::Executor;
+use crate::executor::ExecutorTeardownResult;
 use crate::executor::helpers::command::CommandBuilder;
 use crate::executor::helpers::env::{get_base_injected_env, is_codspeed_debug_enabled};
 use crate::executor::helpers::get_bench_command::get_bench_command;
@@ -195,7 +196,10 @@ impl Executor for WallTimeExecutor {
         Ok(())
     }
 
-    async fn teardown(&self, execution_context: &ExecutionContext) -> Result<()> {
+    async fn teardown(
+        &self,
+        execution_context: &ExecutionContext,
+    ) -> Result<ExecutorTeardownResult> {
         debug!("Copying files to the profile folder");
 
         if let Some(perf) = &self.perf
@@ -205,12 +209,12 @@ impl Executor for WallTimeExecutor {
                 .await?;
         }
 
-        validate_walltime_results(
+        let has_results = validate_walltime_results(
             &execution_context.profile_folder,
             execution_context.config.allow_empty,
         )?;
 
-        Ok(())
+        Ok(ExecutorTeardownResult { has_results })
     }
 }
 


### PR DESCRIPTION
Fixes: #206 

Note: this will only work for `walltime` and `memory` instruments
