### PR TITLE
fix(runner): update warning message format for go runner installation

### DIFF
--- a/src/executor/helpers/introspected_golang/go.sh
+++ b/src/executor/helpers/introspected_golang/go.sh
@@ -43,8 +43,7 @@ if [ "$1" = "test" ]; then
         INSTALLER_VERSION="${CODSPEED_GO_RUNNER_VERSION:-latest}"
         if [ "$INSTALLER_VERSION" = "latest" ]; then
             DOWNLOAD_URL="http://github.com/CodSpeedHQ/codspeed-go/releases/latest/download/codspeed-go-runner-installer.sh"
-            echo "WARNING: Installing the latest version of codspeed-go-runner. This can silently introduce breaking changes." >&2
-            echo "We recommend pinning a specific version via the `go-runner-version` option in the action." >&2
+            echo "::warning::Installing the latest version of codspeed-go-runner. This can silently introduce breaking changes. We recommend pinning a specific version via the \`go-runner-version\` option in the action." >&2
         else
             DOWNLOAD_URL="http://github.com/CodSpeedHQ/codspeed-go/releases/download/v${INSTALLER_VERSION}/codspeed-go-runner-installer.sh"
         fi


### PR DESCRIPTION
what it now looks like (ignore the DEBUG logs, they won't be visible without `CODSPEED_LOG=debug`)
<img width="1929" height="404" alt="image" src="https://github.com/user-attachments/assets/1a4b052b-3371-43b7-8a52-89d81bd68769" />

see this run: https://github.com/CodSpeedHQ/codspeed-go/actions/runs/21355281841
