### PR TITLE
fix: rename `targets` to `benchmarks` in the project_config to match spec

### DIFF
--- a/schemas/codspeed.schema.json
+++ b/schemas/codspeed.schema.json
@@ -4,6 +4,16 @@
   "description": "Project-level configuration from codspeed.yaml file\n\nThis configuration provides default options for the run and exec commands. CLI arguments always take precedence over config file values.",
   "type": "object",
   "properties": {
+    "benchmarks": {
+      "description": "List of benchmark targets to execute",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Target"
+      }
+    },
     "options": {
       "description": "Default options to apply to all benchmark runs",
       "anyOf": [
@@ -14,16 +24,6 @@
           "type": "null"
         }
       ]
-    },
-    "targets": {
-      "description": "List of benchmark targets to execute",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Target"
-      }
     }
   },
   "definitions": {

--- a/src/project_config/interfaces.rs
+++ b/src/project_config/interfaces.rs
@@ -11,7 +11,7 @@ pub struct ProjectConfig {
     /// Default options to apply to all benchmark runs
     pub options: Option<ProjectOptions>,
     /// List of benchmark targets to execute
-    pub targets: Option<Vec<Target>>,
+    pub benchmarks: Option<Vec<Target>>,
 }
 
 /// A benchmark target to execute

--- a/src/project_config/mod.rs
+++ b/src/project_config/mod.rs
@@ -234,7 +234,7 @@ options:
                 }),
                 working_directory: None,
             }),
-            targets: None,
+            benchmarks: None,
         };
 
         let result = config.validate();
@@ -260,7 +260,7 @@ options:
                 }),
                 working_directory: None,
             }),
-            targets: None,
+            benchmarks: None,
         };
 
         let result = config.validate();
@@ -286,7 +286,7 @@ options:
                 }),
                 working_directory: Some("./bench".to_string()),
             }),
-            targets: None,
+            benchmarks: None,
         };
 
         assert!(config.validate().is_ok());

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -235,7 +235,7 @@ pub async fn run(
     let run_target = if args.command.is_empty() {
         // No command provided - check for targets in project config
         let targets = project_config
-            .and_then(|c| c.targets.as_ref())
+            .and_then(|c| c.benchmarks.as_ref())
             .filter(|t| !t.is_empty())
             .ok_or_else(|| {
                 anyhow!("No command provided and no targets defined in codspeed.yaml")


### PR DESCRIPTION
Keeping `targets` alias to avoid breaking changes