### PR TITLE
fix(runner): deserialize memory results as integer

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -151,12 +151,25 @@ nest! {
                 pub total_time: f64,
             }>,
             pub memory: Option<pub struct MemoryResult {
+                #[serde(deserialize_with = "deserialize_i64_from_string")]
                 pub peak_memory: i64,
+                #[serde(deserialize_with = "deserialize_i64_from_string")]
                 pub total_allocated: i64,
+                #[serde(deserialize_with = "deserialize_i64_from_string")]
                 pub alloc_calls: i64,
             }>,
         }>,
     }
+}
+
+// Custom deserializer to convert string values to i64
+fn deserialize_i64_from_string<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+    let s = String::deserialize(deserializer)?;
+    s.parse().map_err(de::Error::custom)
 }
 
 nest! {


### PR DESCRIPTION
Works locally now: 
```
╭──────────────────────────────────────────────────────────╮
│                    Memory Instrument                     │
├────────────┬─────────────┬─────────────────┬─────────────┤
│ Benchmark  │ Peak memory │ Total allocated │ Allocations │
├────────────┼─────────────┼─────────────────┼─────────────┤
│ wait 1sec  │     64.2 KB │          1.1 MB │      16,787 │
│ long body  │       960 B │          1.2 KB │           9 │
│ fibo 10    │         0 B │             0 B │           0 │
│ long body  │       960 B │          1.2 KB │          10 │
│ short body │       480 B │           624 B │           6 │
│ short body │       480 B │           624 B │           6 │
│ short body │       408 B │           432 B │           4 │
│ one        │      1.8 KB │          6.8 KB │          52 │
│ two        │      1.4 KB │          5.8 KB │          43 │
│ wait 1ms   │        10 B │            71 B │          14 │
│ end        │      1.4 KB │          5.8 KB │          43 │
│ short body │       408 B │           432 B │           4 │
│ short body │       608 B │           752 B │           7 │
│ short body │       480 B │           624 B │           6 │
│ fibo 15    │         5 B │             5 B │           1 │
│ wait 500ms │     64.2 KB │        633.1 KB │       8,109 │
│ long body  │       960 B │          1.2 KB │           9 │
│ long body  │       960 B │          1.2 KB │           9 │
╰────────────┴─────────────┴─────────────────┴─────────────╯
```