### PR TITLE
feat: check for repository existence before run in local runs

### DIFF
--- a/src/cli/exec/mod.rs
+++ b/src/cli/exec/mod.rs
@@ -96,9 +96,10 @@ pub async fn execute_with_harness(
     codspeed_config: &CodSpeedConfig,
     setup_cache_dir: Option<&Path>,
 ) -> Result<()> {
-    let mut execution_context = executor::ExecutionContext::try_from((config, codspeed_config))?;
+    let mut execution_context =
+        executor::ExecutionContext::new(config, codspeed_config, api_client).await?;
 
-    if execution_context.is_local() {
+    if !execution_context.is_local() {
         super::show_banner();
     }
 
@@ -128,7 +129,6 @@ pub async fn execute_with_harness(
         &mut execution_context,
         setup_cache_dir,
         poll_results_fn,
-        api_client,
     )
     .await?;
 

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -144,7 +144,7 @@ pub async fn run(
 
             // Create execution context
             let mut execution_context =
-                executor::ExecutionContext::try_from((config, codspeed_config))?;
+                executor::ExecutionContext::new(config, codspeed_config, api_client).await?;
 
             if !execution_context.is_local() {
                 super::show_banner();
@@ -162,7 +162,6 @@ pub async fn run(
                 &mut execution_context,
                 setup_cache_dir,
                 poll_results_fn,
-                api_client,
             )
             .await?;
         }

--- a/src/executor/execution_context.rs
+++ b/src/executor/execution_context.rs
@@ -1,4 +1,5 @@
 use super::Config;
+use crate::api_client::CodSpeedAPIClient;
 use crate::cli::run::logger::Logger;
 use crate::config::CodSpeedConfig;
 use crate::prelude::*;
@@ -29,15 +30,13 @@ impl ExecutionContext {
     pub fn is_local(&self) -> bool {
         self.provider.get_run_environment() == RunEnvironment::Local
     }
-}
 
-impl TryFrom<(Config, &CodSpeedConfig)> for ExecutionContext {
-    type Error = anyhow::Error;
-
-    fn try_from(
-        (mut config, codspeed_config): (Config, &CodSpeedConfig),
-    ) -> Result<Self, Self::Error> {
-        let provider = run_environment::get_provider(&config)?;
+    pub async fn new(
+        mut config: Config,
+        codspeed_config: &CodSpeedConfig,
+        api_client: &CodSpeedAPIClient,
+    ) -> Result<Self> {
+        let provider = run_environment::get_provider(&config, api_client).await?;
         let system_info = SystemInfo::new()?;
         system::check_system(&system_info)?;
         let logger = Logger::new(provider.as_ref())?;

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -11,7 +11,6 @@ mod tests;
 mod valgrind;
 mod wall_time;
 
-use crate::api_client::CodSpeedAPIClient;
 use crate::instruments::mongo_tracer::{MongoTracer, install_mongodb_tracer};
 use crate::prelude::*;
 use crate::runner_mode::RunnerMode;
@@ -89,7 +88,6 @@ pub async fn execute_benchmarks<F>(
     execution_context: &mut ExecutionContext,
     setup_cache_dir: Option<&Path>,
     poll_results: F,
-    api_client: &CodSpeedAPIClient,
 ) -> Result<()>
 where
     F: AsyncFn(&UploadResult) -> Result<()>,
@@ -150,8 +148,7 @@ where
         }
 
         start_group!("Uploading results");
-        let upload_result =
-            crate::upload::upload(execution_context, executor.name(), api_client).await?;
+        let upload_result = crate::upload::upload(execution_context, executor.name()).await?;
 
         if execution_context.is_local() {
             poll_results(&upload_result).await?;

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -132,14 +132,15 @@ fn exec_harness_test_cases() -> Vec<&'static str> {
 fn env_test_cases(#[case] env_case: (&str, &str)) {}
 
 async fn create_test_setup(config: Config) -> (ExecutionContext, TempDir) {
+    use crate::api_client::CodSpeedAPIClient;
     use crate::config::CodSpeedConfig;
     use crate::executor::config::RepositoryOverride;
     use crate::run_environment::interfaces::RepositoryProvider;
 
     let temp_dir = TempDir::new().unwrap();
 
-    // Use try_from to create a proper ExecutionContext with all fields
     let codspeed_config = CodSpeedConfig::default();
+    let api_client = CodSpeedAPIClient::create_test_client();
     let mut config_with_folder = config;
     config_with_folder.profile_folder = Some(temp_dir.path().to_path_buf());
 
@@ -159,7 +160,8 @@ async fn create_test_setup(config: Config) -> (ExecutionContext, TempDir) {
     }
 
     let execution_context =
-        ExecutionContext::try_from((config_with_folder, &codspeed_config_with_token))
+        ExecutionContext::new(config_with_folder, &codspeed_config_with_token, &api_client)
+            .await
             .expect("Failed to create ExecutionContext for test");
 
     (execution_context, temp_dir)

--- a/src/queries/GetRepository.gql
+++ b/src/queries/GetRepository.gql
@@ -1,0 +1,9 @@
+query Repository(
+  $owner: String!
+  $name: String!
+  $provider: RepositoryProvider
+) {
+  repository(owner: $owner, name: $name, provider: $provider) {
+    id
+  }
+}

--- a/src/run_environment/provider.rs
+++ b/src/run_environment/provider.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use git2::Repository;
 use simplelog::SharedLogger;
 
-use crate::api_client::CodSpeedAPIClient;
 use crate::executor::{Config, ExecutorName};
 use crate::prelude::*;
 use crate::system::SystemInfo;
@@ -90,7 +89,6 @@ pub trait RunEnvironmentProvider {
         system_info: &SystemInfo,
         profile_archive: &ProfileArchive,
         executor_name: ExecutorName,
-        _api_client: &CodSpeedAPIClient,
     ) -> Result<UploadMetadata> {
         let run_environment_metadata = self.get_run_environment_metadata()?;
 


### PR DESCRIPTION
Avoids the usecase

1. user installs CLI without having used codspeed before
2. user logins
3. user tries a command within a github repo
4. CodSpeed fails because the user has never imported the repo in codspeed

Note: we do an "easy" check by just checking for existence in codspeed models, in case the repo exists but is misconfigured, it will still behave has before, with a `401` after run