### PR TITLE
fix(runner): panic if integration doesn't support memory profiling

### DIFF
--- a/src/executor/memory/executor.rs
+++ b/src/executor/memory/executor.rs
@@ -196,7 +196,7 @@ impl MemoryExecutor {
                     };
 
                     if cur_version < min_version {
-                        return Ok(Some(FifoCommand::Err));
+                        panic!("{INVALID_INTEGRATION_ERROR}")
                     }
                 }
                 FifoCommand::SetVersion(protocol_version) => {


### PR DESCRIPTION
We can panic, since there's no way that the integration should continue to run when we don't support it. This is needed to prevent running old pytest-codspeed versions with memory instrument, since we only print the errors as warnings.