### PR TITLE
fix: add missing author field to marketplace plugin entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,16 @@
 {
-  "name": "codspeed-plugin-marketplace",
-  "owner": {
-    "name": "CodSpeed"
-  },
-  "plugins": [
-    {
-      "name": "codspeed",
-      "source": "./",
-      "description": "Tools for accurate and reliable performance measurement and optimization"
-    }
-  ]
+    "name": "codspeed-plugin-marketplace",
+    "owner": {
+          "name": "CodSpeed"
+    },
+    "plugins": [
+          {
+                  "name": "codspeed",
+                  "source": "./",
+                  "description": "Tools for accurate and reliable performance measurement and optimization",
+                  "author": {
+                            "name": "CodSpeed"
+                  }
+          }
+    ]
 }


### PR DESCRIPTION
Claude Desktop (Cowork) requires the `author` field on marketplace plugin entries for validation. Without it, adding the marketplace fails with "Failed to add marketplace." Fixes #282.