### PR TITLE
feat: warn when libc debug info is not found

### DIFF
--- a/src/executor/wall_time/perf/save_artifacts.rs
+++ b/src/executor/wall_time/perf/save_artifacts.rs
@@ -124,6 +124,36 @@ fn save_symbols(
     mappings_by_pid
 }
 
+fn is_libc_path(path: &Path) -> bool {
+    let Some(filename) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    // Match libc.so.6, libc-2.31.so, etc. but not unrelated libs like libc-client.so
+    filename.starts_with("libc.so")
+        || (filename.starts_with("libc-")
+            && filename.as_bytes().get(5).is_some_and(u8::is_ascii_digit))
+}
+
+fn warn_missing_libc_debug_info(
+    loaded_modules_by_path: &HashMap<PathBuf, LoadedModule>,
+    debug_info_by_elf_path: &HashMap<PathBuf, ModuleDebugInfo>,
+) {
+    for (path, loaded_module) in loaded_modules_by_path {
+        if !is_libc_path(path) || loaded_module.module_symbols.is_none() {
+            continue;
+        }
+        if debug_info_by_elf_path.contains_key(path) {
+            continue;
+        }
+        warn!(
+            "libc debug info not found for {}. Flamegraphs may contain \
+             unsymbolicated libc frames. Install debug symbols \
+             (e.g., `apt install libc6-dbg`) to fix this.",
+            path.display()
+        );
+    }
+}
+
 /// Compute debug info from symbols and build per-pid debug info mappings.
 fn save_debug_info(
     loaded_modules_by_path: &HashMap<PathBuf, LoadedModule>,
@@ -135,6 +165,8 @@ fn save_debug_info(
     debug!("Saving debug_info");
 
     let debug_info_by_elf_path = debug_info_by_path(loaded_modules_by_path);
+
+    warn_missing_libc_debug_info(loaded_modules_by_path, &debug_info_by_elf_path);
 
     for path in debug_info_by_elf_path.keys() {
         get_or_insert_key(path_to_key, path);


### PR DESCRIPTION
## Summary

- Adds a warning during walltime profile processing when libc is loaded but has no DWARF debug info
- Without `libc-dbg` installed, libc frames in flamegraphs appear as bare hex addresses, making diff comparisons unusable
- The check specifically targets libc (by filename pattern) to avoid false positives from other libraries that may legitimately lack debug info (e.g. JIT-related shared objects deleted at benchmark exit)

## Changes

- Added `is_libc_path()` helper to match libc filenames (`libc.so.6`, `libc-2.31.so`, etc.) while excluding unrelated libraries (`libc-client.so`)
- Added `warn_missing_libc_debug_info()` that compares loaded modules against successfully-extracted debug info and warns for libc modules with missing DWARF data
- Called from `save_debug_info()` right after debug info extraction completes

## Test plan

- [ ] Run a walltime benchmark on a system **without** `libc6-dbg` installed — verify the warning appears in logs
- [ ] Run a walltime benchmark on a system **with** `libc6-dbg` installed — verify no warning appears
- [ ] Verify Go/Java benchmarks (where `libinstrument-hooks.so` is deleted at exit) do **not** trigger the warning