### PR TITLE
fix: update setarch command arguments to use long options

### DIFF
--- a/src/executor/helpers/command.rs
+++ b/src/executor/helpers/command.rs
@@ -141,11 +141,11 @@ mod tests {
         let mut builder = CommandBuilder::new("valgrind");
         builder
             .arg("my-program")
-            .wrap("setarch", ["x86_64", "-R"])
+            .wrap("setarch", ["x86_64", "--addr-no-randomize"])
             .wrap("sudo", ["-n"]);
         assert_eq!(
             builder.as_command_line(),
-            "sudo -n setarch x86_64 -R valgrind my-program"
+            "sudo -n setarch x86_64 --addr-no-randomize valgrind my-program"
         );
     }
 

--- a/src/executor/valgrind/measure.rs
+++ b/src/executor/valgrind/measure.rs
@@ -97,7 +97,7 @@ pub async fn measure(
 
     // Create the command
     let mut cmd = Command::new("setarch");
-    cmd.arg(ARCH).arg("-R");
+    cmd.arg(ARCH).arg("--addr-no-randomize");
     // Configure the environment
     cmd.envs(get_base_injected_env(
         RunnerMode::Simulation,


### PR DESCRIPTION
Replace the short `-R` option with the more explicit `--addr-no-randomize` option to improve clarity.

This change is intended to make `@codspeedbot` output easier to interpret:

https://github.com/uutils/coreutils/pull/11908#issuecomment-4281915697