### PR TITLE
feat: only wrap walltime command with sudo on linux

### DIFF
--- a/src/executor/wall_time/executor.rs
+++ b/src/executor/wall_time/executor.rs
@@ -163,7 +163,12 @@ impl Executor for WallTimeExecutor {
                 )
                 .await
             } else {
-                let cmd = wrap_with_sudo(cmd_builder)?.build();
+                let cmd_builder = if cfg!(target_os = "linux") {
+                    wrap_with_sudo(cmd_builder)?
+                } else {
+                    cmd_builder
+                };
+                let cmd = cmd_builder.build();
                 debug!("cmd: {cmd:?}");
                 run_command_with_log_pipe(cmd).await
             }

--- a/src/upload/benchmark_display.rs
+++ b/src/upload/benchmark_display.rs
@@ -29,6 +29,9 @@ fn format_with_thousands_sep(n: u64) -> String {
 
 /// Format StdDev with color coding based on value
 fn format_stdev_colored(stdev_pct: f64) -> String {
+    if !stdev_pct.is_finite() {
+        return format!("{}", style("N/A").dim());
+    }
     let formatted = format!("{stdev_pct:.2}%");
     if stdev_pct <= 2.0 {
         format!("{}", style(&formatted).green())


### PR DESCRIPTION
We do not yet need sudo, since we don't use launchtl nor profilers yet.

<img width="679" height="591" alt="image" src="https://github.com/user-attachments/assets/8b2bb13f-2887-402e-abe8-700e9467ecde" />
