### PR TITLE
chore: add missing type field and add a getting started section

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "CodSpeed": {
+      "type": "http",
       "url": "https://mcp.codspeed.io/mcp"
     }
   }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,22 @@
 # Contributing to CodSpeed Runner
 
+## Getting Started
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/)
+- [Git LFS](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) (required for test fixtures)
+
+### Setup
+
+After cloning the repository, initialize the submodules and fetch the test fixtures:
+
+```bash
+git submodule update --init --recursive
+git lfs install
+git lfs pull
+```
+
 ## Release Process
 
 This repository is a Cargo workspace containing multiple crates. The release process differs depending on which crate you're releasing.


### PR DESCRIPTION
Related issue: #316 

---

- Add missing `type` key inside `.mcp.json` to avoid Claude Code warning when running inside the cloned repo.

- Add a getting started section in `CONTRIBUTING.md` to have the prerequisites before running `cargo build` and `cargo test`

> Note: it can be added in `AGENT.md` or any relevant placed if `CONTRIBUTING.md` is not suited
