### PR TITLE
feat(system): detect ubuntu/debian derivative distros via id_like fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
  "shellexpand",
  "simplelog",
  "strum",
- "sysinfo 0.33.1",
+ "sysinfo 0.38.4",
  "tabled",
  "temp-env",
  "tempfile",
@@ -4159,21 +4159,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "serde",
- "windows 0.57.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
@@ -4184,6 +4169,21 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.61.3",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "serde",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5098,16 +5098,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -5122,11 +5112,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5139,15 +5141,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.57.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5197,18 +5196,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5227,17 +5226,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5289,6 +5277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,15 +5295,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5487,6 +5476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ git2 = "0.20.4"
 nestify = "0.3.3"
 gql_client = { git = "https://github.com/CodSpeedHQ/gql-client-rs" }
 serde_yaml = "0.9.34"
-sysinfo = { version = "0.33.1", features = ["serde"] }
+sysinfo = { version = "0.38.4", features = ["serde"] }
 indicatif = "0.17.8"
 console = "0.15.8"
 async-trait = "0.1.82"

--- a/src/system/info.rs
+++ b/src/system/info.rs
@@ -109,9 +109,8 @@ impl SystemInfo {
                 .with_cpu(CpuRefreshKind::everything())
                 .with_memory(MemoryRefreshKind::everything()),
         );
-        let cpu_cores = s
-            .physical_core_count()
-            .ok_or(anyhow!("Failed to get CPU core count"))?;
+        let cpu_cores =
+            System::physical_core_count().ok_or(anyhow!("Failed to get CPU core count"))?;
         let total_memory_gb = s.total_memory().div_ceil(1024_u64.pow(3));
 
         // take the first CPU to get the brand, name and vendor id

--- a/src/system/os.rs
+++ b/src/system/os.rs
@@ -26,7 +26,12 @@ impl SupportedOs {
         match os {
             "linux" => {
                 let os_id = System::distribution_id();
-                Ok(Self::Linux(LinuxDistribution::from_id(&os_id, &os_version)))
+                let os_id_like = System::distribution_id_like();
+                Ok(Self::Linux(LinuxDistribution::from_id_like(
+                    &os_id,
+                    &os_id_like,
+                    &os_version,
+                )))
             }
             "macos" => Ok(Self::Macos {
                 version: os_version,
@@ -99,6 +104,21 @@ impl LinuxDistribution {
         }
     }
 
+    /// Build a [`LinuxDistribution`] from the `sysinfo`-reported `os_id` and `os_id_like` fields.
+    /// This is needed to handle cases like PopOS (`os_id` = "pop" and `os_id_like` = ["ubuntu"]).
+    fn from_id_like(os_id: &str, os_id_like: &[String], version: &str) -> Self {
+        let by_id = Self::from_id(os_id, version);
+        if matches!(by_id, Self::Other { .. }) {
+            for like_id in os_id_like {
+                let by_like_id = Self::from_id(like_id, version);
+                if !matches!(by_like_id, Self::Other { .. }) {
+                    return by_like_id;
+                }
+            }
+        }
+        by_id
+    }
+
     /// The distro id as it appears on the wire (matches `sysinfo::System::distribution_id()`).
     pub fn id(&self) -> &str {
         match self {
@@ -136,5 +156,43 @@ mod tests {
     fn from_os_bails_on_unsupported() {
         let err = SupportedOs::from_os("windows").unwrap_err();
         assert_eq!(err.to_string(), "Unsupported operating system: windows");
+    }
+
+    #[test]
+    fn pop_os_resolves_to_ubuntu_via_id_like() {
+        // Pop!_OS: ID=pop, ID_LIKE="ubuntu debian"
+        let distro = LinuxDistribution::from_id_like(
+            "pop",
+            &[String::from("ubuntu"), String::from("debian")],
+            "24.04",
+        );
+        assert!(
+            matches!(distro, LinuxDistribution::Ubuntu { .. }),
+            "got {distro}"
+        );
+    }
+
+    #[test]
+    fn ubuntu_resolves_directly_without_id_like() {
+        // Ubuntu laptop: ID=ubuntu, ID_LIKE="debian" — primary id wins, no fallback needed
+        let distro = LinuxDistribution::from_id_like("ubuntu", &[String::from("debian")], "24.04");
+        assert!(
+            matches!(distro, LinuxDistribution::Ubuntu { .. }),
+            "got {distro}"
+        );
+    }
+
+    #[test]
+    fn centos_with_unrecognized_parents_is_other() {
+        // CentOS server: ID=centos, ID_LIKE="rhel fedora" — neither parent is known
+        let distro = LinuxDistribution::from_id_like(
+            "centos",
+            &[String::from("rhel"), String::from("fedora")],
+            "9",
+        );
+        assert!(
+            matches!(&distro, LinuxDistribution::Other { name, .. } if name == "centos"),
+            "got {distro}"
+        );
     }
 }


### PR DESCRIPTION
Closes #326

## Summary

- Upgrade `sysinfo` to `0.38.4` to access `System::distribution_id_like()`
- Add `LinuxDistribution::from_id_like()` which falls back to the `ID_LIKE` parent chain when the primary distro ID is unrecognized
- Adapt `System::physical_core_count()` call site in `system/info.rs` (became an associated function in `0.38`)

## Test plan

- `pop_os_resolves_to_ubuntu_via_id_like` — primary fix case
- `ubuntu_resolves_directly_without_id_like` — existing behavior unchanged
- `centos_with_unrecognized_parents_is_other` — unrecognized lineage stays `Other`
- All existing tests pass

---

ofc if it does not comply with your needs, you can close the PR 👍 