### PR TITLE
feat: add a way to disable perf compression through env var

### DIFF
--- a/src/executor/wall_time/perf/perf_executable.rs
+++ b/src/executor/wall_time/perf/perf_executable.rs
@@ -134,6 +134,10 @@ pub fn get_compression_flags<S: AsRef<Path>>(perf_executable: S) -> Result<Optio
 
     if has_zstd {
         debug!("perf supports zstd compression");
+        if std::env::var("CODSPEED_PERF_DISABLE_COMPRESSION").is_ok() {
+            info!("CODSPEED_PERF_DISABLE_COMPRESSION is set, disabling perf compression");
+            return Ok(None);
+        }
         // 3 is a widely adopted default level (AWS Athena, Python, ...)
         Ok(Some("--compression-level=3".to_string()))
     } else {


### PR DESCRIPTION
This is aimed to be dev only, because some profilers do not support compressed perf data, namely hotspot.