### PR TITLE
fix(cli): preserve argument quoting for SingleCommand

### DIFF
--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -177,7 +177,7 @@ pub async fn run(
         RunTarget::SingleCommand(args) => {
             // SingleCommand: working_directory comes from --working-directory CLI flag only.
             // Config file's working-directory is NOT used.
-            let command = args.command.join(" ");
+            let command = shell_words::join(&args.command);
             let poll_opts = PollResultsOptions::new(output_json, base_run_id);
             let config = build_orchestrator_config(
                 args,


### PR DESCRIPTION
## Summary
- Replace naive `args.command.join(\" \")` with `shell_words::join` when reconstructing the command string for `SingleCommand`, so arguments containing spaces or shell metacharacters are properly quoted before being passed to the orchestrator.

## Test plan
- [ ] `cargo test`
- [ ] Run `codspeed run -- some-cmd 'arg with spaces'` and confirm the argument is preserved as a single token.