### PR TITLE
fix(skills): misleading DCE advice in setup-harness

### DIFF
--- a/skills/codspeed-setup-harness/SKILL.md
+++ b/skills/codspeed-setup-harness/SKILL.md
@@ -287,7 +287,7 @@ Good benchmarks are representative, isolated, and stable. Here are guidelines:
 
 - **Avoid benchmarking setup**: Use the framework's setup/teardown mechanisms to exclude initialization from measurements.
 
-- **Prevent dead code elimination**: Use `black_box()` (Rust), `benchmark.pedantic()` (Python), or equivalent to ensure the compiler/runtime doesn't optimize away the work you're measuring.
+- **Prevent dead code elimination**: Use `black_box()` (Rust), `benchmark::DoNotOptimize` (C++), or `Blackhole.consume` (JMH) so the compiler doesn't optimize away unused results.
 
 - **Cover the critical path**: Benchmark the functions that matter most to your users — the ones called frequently or on the hot path.
 


### PR DESCRIPTION
The skill told users to use `benchmark.pedantic()` in Python to prevent dead code elimination, like `black_box()` in Rust. Two problems with that.

`benchmark.pedantic` does not prevent dead code elimination. It just lets you set rounds, iterations, and a setup function for the benchmark.

CPython does not delete unused function calls. It can't know if a function has side effects, so it always runs it. Pure-Python benchmarks do not need a `black_box`.

The new wording only mentions compiled languages and uses the right name for each one.