### PR TITLE
chore/bump valgrind codspeed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "codspeed-runner"
-version = "4.16.1"
+version = "4.16.2-alpha.1"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codspeed-runner"
-version = "4.16.1"
+version = "4.16.2-alpha.1"
 edition = "2024"
 repository = "https://github.com/CodSpeedHQ/codspeed"
 publish = false

--- a/src/executor/valgrind/setup.rs
+++ b/src/executor/valgrind/setup.rs
@@ -201,7 +201,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_filename(&system_info).unwrap(),
-            @"valgrind_3.26.0-0codspeed0_ubuntu-22.04_amd64.deb"
+            @"valgrind_3.26.0-0codspeed1_ubuntu-22.04_amd64.deb"
         );
     }
 
@@ -216,7 +216,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_filename(&system_info).unwrap(),
-            @"valgrind_3.26.0-0codspeed0_ubuntu-24.04_amd64.deb"
+            @"valgrind_3.26.0-0codspeed1_ubuntu-24.04_amd64.deb"
         );
     }
 
@@ -231,7 +231,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_filename(&system_info).unwrap(),
-            @"valgrind_3.26.0-0codspeed0_ubuntu-22.04_amd64.deb"
+            @"valgrind_3.26.0-0codspeed1_ubuntu-22.04_amd64.deb"
         );
     }
 
@@ -246,7 +246,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_filename(&system_info).unwrap(),
-            @"valgrind_3.26.0-0codspeed0_ubuntu-22.04_arm64.deb"
+            @"valgrind_3.26.0-0codspeed1_ubuntu-22.04_arm64.deb"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const MONGODB_TRACER_VERSION: &str = "cs-mongo-tracer-v0.2.0";
 
 pub const VALGRIND_CODSPEED_VERSION: Version = Version::new(3, 26, 0);
-pub const VALGRIND_CODSPEED_DEB_REVISION_SUFFIX: &str = "0codspeed0";
+pub const VALGRIND_CODSPEED_DEB_REVISION_SUFFIX: &str = "0codspeed1";
 pub static VALGRIND_CODSPEED_VERSION_STRING: LazyLock<String> =
     LazyLock::new(|| format!("{VALGRIND_CODSPEED_VERSION}.codspeed"));
 pub static VALGRIND_CODSPEED_DEB_VERSION: LazyLock<String> = LazyLock::new(|| {


### PR DESCRIPTION
- **feat: bump valgrind-codspeed to 3.26.0-0codspeed1**
- **chore: Release codspeed-runner version 4.16.2-alpha.1 🎉**
