### PR TITLE
fix(logger): flush rolling buffer when executor errors

### DIFF
--- a/src/executor/orchestrator.rs
+++ b/src/executor/orchestrator.rs
@@ -154,11 +154,16 @@ impl Orchestrator {
                 activate_rolling_buffer(&part.label);
             }
 
-            run_executor(executor.as_mut(), self, &ctx, setup_cache_dir).await?;
+            let result = run_executor(executor.as_mut(), self, &ctx, setup_cache_dir).await;
 
+            // Always tear the rolling buffer down before propagating the error,
+            // otherwise deferred warnings and the final error message would be
+            // swallowed by the deferred-logs queue.
             if !self.config.show_full_output {
                 deactivate_rolling_buffer();
             }
+
+            result?;
             all_completed_runs.push((ctx, executor.name()));
         }
 


### PR DESCRIPTION
## Summary

- When `run_executor` returns `Err`, the `?` short-circuit was skipping `deactivate_rolling_buffer()`. The rolling buffer stayed active in its global static, so both the deferred profiler warning (e.g. "Walltime profiling is enabled, but failed to detect benchmarks") and the final error printed by `main` via `log::error!` ended up queued in `DEFERRED_LOGS` and never flushed — the user saw the box close and the prompt return with no indication of what went wrong.
- Capture the result, run `deactivate_rolling_buffer()` unconditionally, then propagate. `finish()` triggers `flush_deferred_logs()`, so queued warnings render above the final box, and by the time `main` calls `log::error!` the rolling buffer is `None` and the error prints normally.

Closes [COD-2665](https://linear.app/codspeed/issue/COD-2665/showing-output-in-box-hides-error-messages)

## Test plan

- [ ] `cargo r -- run --mode walltime -- ls` shows the "Walltime profiling is enabled, but failed to detect benchmarks" warning and the "did not produce any CodSpeed result" error after the box closes
- [ ] `cargo r -- run --show-full-output --mode walltime -- ls` behavior unchanged
- [ ] Successful runs still tear the box down cleanly with a checkmark