### PR TITLE
ci: fix macOS rustup cache corruption in install-rust action

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Install rust-toolchain.toml
       shell: bash
-      run: rustup show
+      run: rustup toolchain install
     - name: Install additional rustup components
       if: inputs.components != ''
       shell: bash
@@ -22,3 +22,5 @@ runs:
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       with:
         key: ${{ inputs.cache-key }}
+        # https://github.com/Swatinem/rust-cache/issues/341
+        cache-bin: ${{ runner.os != 'macOS' }}


### PR DESCRIPTION
Switch the install-rust composite action back to `rustup toolchain install` and disable `cache-bin` on the rust-cache step for macOS.

macOS lint jobs were failing with:

```
error: unexpected argument 'fmt' found
Usage: rustup-init[EXE] [OPTIONS]
```

Two compounding causes:

- `rustup show` was used to materialize the toolchain pinned in `rust-toolchain.toml`. Per the [rustup 1.28 release notes](https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md), `rustup show` no longer auto-installs the active toolchain — the documented replacement is `rustup toolchain install` (with no arguments). Behavior was partially restored in 1.28.1 behind `RUSTUP_AUTO_INSTALL`, so relying on `rustup show` is fragile across runner image updates.
- `Swatinem/rust-cache` caches `~/.cargo/bin` by default. On macOS, the cache had been saved on a runner with a different rustup version; on restore it overwrote the freshly-installed cargo proxy with a stale `rustup-init` binary, which is why `cargo fmt`/`cargo clippy` reported `Usage: rustup-init[EXE]`.

This matches the pattern tokio uses ([tokio-rs/tokio CI](https://github.com/tokio-rs/tokio/blob/master/.github/workflows/ci.yml)): install the toolchain first, then run rust-cache with `cache-bin: false` on macOS only.



Tested with 10 runs of just the macos lint