### PR TITLE
ci: shard bpf-tests by integration test binary

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Comma-separated list of additional rustup components to install (e.g. "rustfmt, clippy").
     required: false
     default: ""
+  cache-key:
+    description: Extra value appended to the rust-cache key, used to give matrix shards distinct caches and avoid concurrent save races.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -16,3 +20,5 @@ runs:
       shell: bash
       run: echo "${{ inputs.components }}" | tr ',' '\n' | xargs rustup component add
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      with:
+        key: ${{ inputs.cache-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
 
   bpf-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each memtrack integration test binary runs its cases serially
+        # (eBPF tracker can't overlap with itself in one process), so we
+        # shard at the test-binary level to parallelize across jobs.
+        test: [c_tests, cpp_tests, rust_tests, spawn_tests]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -102,7 +109,7 @@ jobs:
       - name: Run tests
         env:
           RUST_LOG: debug
-        run: sudo -E $(which cargo) test -- --test-threads 1 --nocapture
+        run: sudo -E $(which cargo) test --lib --test ${{ matrix.test }} -- --test-threads 1 --nocapture
         working-directory: crates/memtrack
 
       # Since we ran the tests with sudo, the build artifacts will have root ownership

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           lfs: true
           submodules: true
       - uses: ./.github/actions/install-rust
+        with:
+          cache-key: ${{ matrix.test }}
       - name: Install dependencies required for libbpf-sys (vendored feature)
         run: sudo apt-get update && sudo apt-get install -y autopoint bison flex
 


### PR DESCRIPTION
## Summary

The `bpf-tests` job is the long pole of CI at ~13min, while every other job finishes in under 5min. Breakdown of the slow step on a recent run:

| stage | time |
|---|---|
| build/deps | ~1m15s |
| `c_tests` | 3m38s (8 cases, serial) |
| `cpp_tests` | 3m44s (7 cases, serial) |
| `rust_tests` | 2m21s (3 cases, serial) |
| `spawn_tests` | 1m03s (2 cases) |

Each memtrack integration test binary runs its cases serially because the eBPF tracker can't safely overlap with itself in one process (`--test-threads 1`). That's a per-binary constraint though — different test binaries are fully independent.

This shards `bpf-tests` into four matrix jobs, one per integration test binary. Each shard builds only the binary it needs and runs its cases as before. Critical path drops from ~13min to ~5min (longest shard ≈ cpp_tests).

## Test plan

- [ ] All four `bpf-tests (...)` matrix jobs pass
- [ ] `check` job correctly waits for the whole matrix and turns green