### PR TITLE
fix: use introspected env for memory executor

### DIFF
--- a/src/binary_pins.rs
+++ b/src/binary_pins.rs
@@ -218,19 +218,35 @@ mod tests {
     #[test_with::env(GITHUB_ACTIONS)]
     #[tokio::test(flavor = "multi_thread")]
     async fn all_pinned_binaries_match_their_declared_sha256() {
-        let results = futures::future::join_all(all_pinned_binaries().map(|binary| async move {
-            let temp = NamedTempFile::new().expect("failed to create temp file");
-            download_pinned_file(binary, temp.path())
-                .await
-                .map_err(|e| format!("{binary:?} ({}): {e}", binary.url()))
-        }))
-        .await;
+        // Downloads occasionally fail with a 200 with GitHub...
+        const MAX_ATTEMPTS: u32 = 3;
 
-        let failures: Vec<_> = results.into_iter().filter_map(Result::err).collect();
-        assert!(
-            failures.is_empty(),
-            "pinned binaries failed verification:\n  - {}",
-            failures.join("\n  - "),
+        let mut last_failures: Vec<String> = Vec::new();
+        for attempt in 1..=MAX_ATTEMPTS {
+            let results =
+                futures::future::join_all(all_pinned_binaries().map(|binary| async move {
+                    let temp = NamedTempFile::new().expect("failed to create temp file");
+                    download_pinned_file(binary, temp.path())
+                        .await
+                        .map_err(|e| format!("{binary:?} ({}): {e}", binary.url()))
+                }))
+                .await;
+
+            last_failures = results.into_iter().filter_map(Result::err).collect();
+            if last_failures.is_empty() {
+                return;
+            }
+
+            eprintln!(
+                "attempt {attempt}/{MAX_ATTEMPTS} failed for {} binaries:\n  - {}",
+                last_failures.len(),
+                last_failures.join("\n  - "),
+            );
+        }
+
+        panic!(
+            "pinned binaries failed verification after {MAX_ATTEMPTS} attempts:\n  - {}",
+            last_failures.join("\n  - "),
         );
     }
 }

--- a/src/executor/memory/executor.rs
+++ b/src/executor/memory/executor.rs
@@ -2,7 +2,7 @@ use crate::executor::ExecutorName;
 use crate::executor::ExecutorSupport;
 use crate::executor::ToolStatus;
 use crate::executor::helpers::command::CommandBuilder;
-use crate::executor::helpers::env::get_base_injected_env;
+use crate::executor::helpers::env::{build_path_env, get_base_injected_env};
 use crate::executor::helpers::get_bench_command::get_bench_command;
 use crate::executor::helpers::run_command_with_log_pipe::run_command_with_log_pipe_and_callback;
 use crate::executor::helpers::run_with_env::wrap_with_env;
@@ -35,7 +35,16 @@ impl MemoryExecutor {
     fn build_memtrack_command(
         execution_context: &ExecutionContext,
     ) -> Result<(MemtrackIpcServer, CommandBuilder, NamedTempFile)> {
-        // FIXME: We only support native languages for now
+        let mut extra_env = get_base_injected_env(
+            RunnerMode::Memory,
+            &execution_context.profile_folder,
+            &execution_context.config,
+        );
+
+        extra_env.insert(
+            "PATH".into(),
+            build_path_env(execution_context.config.enable_introspection)?,
+        );
 
         // Setup memtrack IPC server
         let (ipc_server, server_name) = ipc::IpcOneShotServer::new()?;
@@ -55,12 +64,6 @@ impl MemoryExecutor {
             cmd_builder.current_dir(abs_cwd);
         }
 
-        // Wrap command with environment forwarding
-        let extra_env = get_base_injected_env(
-            RunnerMode::Memory,
-            &execution_context.profile_folder,
-            &execution_context.config,
-        );
         let (cmd_builder, env_file) = wrap_with_env(cmd_builder, &extra_env)?;
 
         Ok((ipc_server, cmd_builder, env_file))


### PR DESCRIPTION
codspeed-node integration tests were failing silently for a while now.