### PR TITLE
fix(runner): keep rolling buffer off during executor setup

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -14,6 +14,7 @@ mod valgrind;
 mod wall_time;
 
 use crate::instruments::mongo_tracer::{MongoTracer, install_mongodb_tracer};
+use crate::local_logger::rolling_buffer::{activate_rolling_buffer, deactivate_rolling_buffer};
 use crate::prelude::*;
 use crate::runner_mode::RunnerMode;
 use crate::system::SystemInfo;
@@ -157,6 +158,7 @@ pub async fn run_executor(
     orchestrator: &Orchestrator,
     execution_context: &ExecutionContext,
     setup_cache_dir: Option<&Path>,
+    rolling_buffer_label: Option<&str>,
 ) -> Result<()> {
     match executor.support_level(&orchestrator.system_info) {
         ExecutorSupport::Unsupported => {
@@ -197,7 +199,14 @@ pub async fn run_executor(
                 None
             };
 
-        executor.run(execution_context, &mongo_tracer).await?;
+        if let Some(label) = rolling_buffer_label {
+            activate_rolling_buffer(label);
+        }
+        let run_result = executor.run(execution_context, &mongo_tracer).await;
+        if rolling_buffer_label.is_some() {
+            deactivate_rolling_buffer();
+        }
+        run_result?;
 
         // TODO: refactor and move directly in the Instruments struct as a `stop` method
         if let Some(mut mongo_tracer) = mongo_tracer {

--- a/src/executor/orchestrator.rs
+++ b/src/executor/orchestrator.rs
@@ -7,7 +7,6 @@ use crate::cli::run::logger::Logger;
 use crate::executor::config::BenchmarkTarget;
 use crate::executor::config::OrchestratorConfig;
 use crate::executor::helpers::profile_folder::create_profile_folder;
-use crate::local_logger::rolling_buffer::{activate_rolling_buffer, deactivate_rolling_buffer};
 use crate::prelude::*;
 use crate::run_environment::{self, RunEnvironment, RunEnvironmentProvider};
 use crate::runner_mode::RunnerMode;
@@ -151,20 +150,18 @@ impl Orchestrator {
 
             let ctx = ExecutionContext::new(config, profile_folder);
 
-            if !self.config.show_full_output {
-                activate_rolling_buffer(&part.label);
-            }
+            let rolling_buffer_label =
+                (!self.config.show_full_output).then_some(part.label.as_str());
 
-            let result = run_executor(executor.as_mut(), self, &ctx, setup_cache_dir).await;
+            run_executor(
+                executor.as_mut(),
+                self,
+                &ctx,
+                setup_cache_dir,
+                rolling_buffer_label,
+            )
+            .await?;
 
-            // Always tear the rolling buffer down before propagating the error,
-            // otherwise deferred warnings and the final error message would be
-            // swallowed by the deferred-logs queue.
-            if !self.config.show_full_output {
-                deactivate_rolling_buffer();
-            }
-
-            result?;
             all_completed_runs.push((ctx, executor.name()));
         }
 


### PR DESCRIPTION
Correctly prints the Sudo prompt now:
```
$ codspeed run -m memory -- eza /nix/store

› Running the benchmarks

  Granting codspeed-memtrack the capabilities it needs as a one-time setup for the memory instrument (requires sudo).
  Sudo privileges are required to continue.
Place your right index finger on the fingerprint reader
```

Fixes #410 