### PR TITLE
Handle Linux distros without VERSION_ID

### DIFF
--- a/src/system/os.rs
+++ b/src/system/os.rs
@@ -66,7 +66,6 @@ impl SupportedOs {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
 struct OsRelease {
     version_id: Option<String>,
     build_id: Option<String>,
@@ -96,7 +95,17 @@ impl OsRelease {
             let Some((key, value)) = line.split_once('=') else {
                 continue;
             };
-            let value = Self::unquote_value(value.trim()).to_string();
+            let value = value.trim();
+            let value = value
+                .strip_prefix('"')
+                .and_then(|value| value.strip_suffix('"'))
+                .or_else(|| {
+                    value
+                        .strip_prefix('\'')
+                        .and_then(|value| value.strip_suffix('\''))
+                })
+                .unwrap_or(value)
+                .to_string();
 
             match key.trim() {
                 "VERSION_ID" => release.version_id = Some(value),
@@ -110,24 +119,6 @@ impl OsRelease {
 
     fn version(&self) -> Option<&str> {
         self.version_id.as_deref().or(self.build_id.as_deref())
-    }
-
-    fn unquote_value(value: &str) -> &str {
-        if let Some(value) = value
-            .strip_prefix('"')
-            .and_then(|value| value.strip_suffix('"'))
-        {
-            return value;
-        }
-
-        if let Some(value) = value
-            .strip_prefix('\'')
-            .and_then(|value| value.strip_suffix('\''))
-        {
-            return value;
-        }
-
-        value
     }
 }
 

--- a/src/system/os.rs
+++ b/src/system/os.rs
@@ -29,11 +29,19 @@ impl SupportedOs {
         match os {
             "linux" => {
                 let os_id = System::distribution_id();
-                let os_version = linux_os_version()?;
+                let os_version = System::os_version()
+                    .or_else(|| {
+                        OsRelease::read().and_then(|release| release.version().map(str::to_owned))
+                    })
+                    .ok_or(anyhow!(
+                        "Failed to get Linux OS version from sysinfo or os-release"
+                    ))?;
+
                 Ok(Self::Linux(LinuxDistribution::from_id(&os_id, &os_version)))
             }
             "macos" => {
                 let os_version = System::os_version().ok_or(anyhow!("Failed to get OS version"))?;
+
                 Ok(Self::Macos {
                     version: os_version,
                 })
@@ -58,60 +66,69 @@ impl SupportedOs {
     }
 }
 
-fn linux_os_version() -> Result<String> {
-    System::os_version()
-        .or_else(read_linux_os_release_version)
-        .ok_or(anyhow!(
-            "Failed to get Linux OS version from sysinfo or os-release"
-        ))
+#[derive(Debug, Eq, PartialEq)]
+struct OsRelease {
+    version_id: Option<String>,
+    build_id: Option<String>,
 }
 
-fn read_linux_os_release_version() -> Option<String> {
-    ["/etc/os-release", "/usr/lib/os-release"]
-        .into_iter()
-        .find_map(|path| {
-            fs::read_to_string(path)
-                .ok()
-                .and_then(|contents| parse_os_release_version(&contents))
-        })
-}
-
-fn parse_os_release_version(contents: &str) -> Option<String> {
-    os_release_value(contents, "VERSION_ID").or_else(|| os_release_value(contents, "BUILD_ID"))
-}
-
-fn os_release_value(contents: &str, key: &str) -> Option<String> {
-    contents.lines().find_map(|line| {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            return None;
-        }
-
-        let (candidate, value) = line.split_once('=')?;
-        if candidate.trim() != key {
-            return None;
-        }
-
-        Some(unquote_os_release_value(value.trim()).to_string())
-    })
-}
-
-fn unquote_os_release_value(value: &str) -> &str {
-    if let Some(value) = value
-        .strip_prefix('"')
-        .and_then(|value| value.strip_suffix('"'))
-    {
-        return value;
+impl OsRelease {
+    fn read() -> Option<Self> {
+        ["/etc/os-release", "/usr/lib/os-release"]
+            .into_iter()
+            .filter_map(|path| fs::read_to_string(path).ok())
+            .map(|contents| Self::parse(&contents))
+            .find(|release| release.version().is_some())
     }
 
-    if let Some(value) = value
-        .strip_prefix('\'')
-        .and_then(|value| value.strip_suffix('\''))
-    {
-        return value;
+    fn parse(contents: &str) -> Self {
+        let mut release = Self {
+            version_id: None,
+            build_id: None,
+        };
+
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            let value = Self::unquote_value(value.trim()).to_string();
+
+            match key.trim() {
+                "VERSION_ID" => release.version_id = Some(value),
+                "BUILD_ID" => release.build_id = Some(value),
+                _ => {}
+            }
+        }
+
+        release
     }
 
-    value
+    fn version(&self) -> Option<&str> {
+        self.version_id.as_deref().or(self.build_id.as_deref())
+    }
+
+    fn unquote_value(value: &str) -> &str {
+        if let Some(value) = value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+        {
+            return value;
+        }
+
+        if let Some(value) = value
+            .strip_prefix('\'')
+            .and_then(|value| value.strip_suffix('\''))
+        {
+            return value;
+        }
+
+        value
+    }
 }
 
 impl Display for SupportedOs {
@@ -202,44 +219,53 @@ mod tests {
     }
 
     #[test]
-    fn parse_os_release_version_prefers_version_id() {
+    fn os_release_version_prefers_version_id() {
         let contents = r#"
             ID=ubuntu
             VERSION_ID="24.04"
             BUILD_ID=rolling
         "#;
+        let release = OsRelease::parse(contents);
 
-        assert_eq!(parse_os_release_version(contents).as_deref(), Some("24.04"));
+        assert_eq!(release.version(), Some("24.04"));
     }
 
     #[test]
-    fn parse_os_release_version_falls_back_to_build_id() {
+    fn os_release_version_falls_back_to_build_id() {
         let contents = r#"
             NAME="Arch Linux"
             ID=arch
             BUILD_ID=rolling
         "#;
+        let release = OsRelease::parse(contents);
 
-        assert_eq!(
-            parse_os_release_version(contents).as_deref(),
-            Some("rolling")
-        );
+        assert_eq!(release.version(), Some("rolling"));
     }
 
     #[test]
-    fn parse_os_release_version_handles_single_quoted_values() {
+    fn os_release_parse_handles_single_quoted_values() {
         let contents = "ID=example\nVERSION_ID='1.2'\n";
+        let release = OsRelease::parse(contents);
 
-        assert_eq!(parse_os_release_version(contents).as_deref(), Some("1.2"));
+        assert_eq!(release.version(), Some("1.2"));
     }
 
     #[test]
-    fn parse_os_release_version_returns_none_without_version_fields() {
+    fn os_release_parse_allows_whitespace_around_key() {
+        let contents = "VERSION_ID = \"24.04\"\n";
+        let release = OsRelease::parse(contents);
+
+        assert_eq!(release.version(), Some("24.04"));
+    }
+
+    #[test]
+    fn os_release_version_returns_none_without_version_fields() {
         let contents = r#"
             NAME="Unknown Linux"
             ID=unknown
         "#;
+        let release = OsRelease::parse(contents);
 
-        assert_eq!(parse_os_release_version(contents), None);
+        assert_eq!(release.version(), None);
     }
 }

--- a/src/system/os.rs
+++ b/src/system/os.rs
@@ -33,9 +33,9 @@ impl SupportedOs {
                     .or_else(|| {
                         OsRelease::read().and_then(|release| release.version().map(str::to_owned))
                     })
-                    .ok_or(anyhow!(
-                        "Failed to get Linux OS version from sysinfo or os-release"
-                    ))?;
+                    .ok_or_else(|| {
+                        anyhow!("Failed to get Linux OS version from sysinfo or os-release")
+                    })?;
 
                 Ok(Self::Linux(LinuxDistribution::from_id(&os_id, &os_version)))
             }

--- a/src/system/os.rs
+++ b/src/system/os.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    fs,
+};
 
 use serde::{Deserialize, Serialize};
 use sysinfo::System;
@@ -20,17 +23,21 @@ impl SupportedOs {
     /// Expects `std::env::consts::OS` as input
     ///
     /// For Linux, the distribution is identified via `sysinfo::System::distribution_id()`.
-    /// The OS version is read from `sysinfo::System::os_version()`.
+    /// The OS version is read from `sysinfo::System::os_version()`, falling back to
+    /// `VERSION_ID` or `BUILD_ID` from os-release.
     pub fn from_os(os: &str) -> Result<Self> {
-        let os_version = System::os_version().ok_or(anyhow!("Failed to get OS version"))?;
         match os {
             "linux" => {
                 let os_id = System::distribution_id();
+                let os_version = linux_os_version()?;
                 Ok(Self::Linux(LinuxDistribution::from_id(&os_id, &os_version)))
             }
-            "macos" => Ok(Self::Macos {
-                version: os_version,
-            }),
+            "macos" => {
+                let os_version = System::os_version().ok_or(anyhow!("Failed to get OS version"))?;
+                Ok(Self::Macos {
+                    version: os_version,
+                })
+            }
             unsupported => bail!("Unsupported operating system: {unsupported}"),
         }
     }
@@ -49,6 +56,62 @@ impl SupportedOs {
             Self::Macos { version } => version,
         }
     }
+}
+
+fn linux_os_version() -> Result<String> {
+    System::os_version()
+        .or_else(read_linux_os_release_version)
+        .ok_or(anyhow!(
+            "Failed to get Linux OS version from sysinfo or os-release"
+        ))
+}
+
+fn read_linux_os_release_version() -> Option<String> {
+    ["/etc/os-release", "/usr/lib/os-release"]
+        .into_iter()
+        .find_map(|path| {
+            fs::read_to_string(path)
+                .ok()
+                .and_then(|contents| parse_os_release_version(&contents))
+        })
+}
+
+fn parse_os_release_version(contents: &str) -> Option<String> {
+    os_release_value(contents, "VERSION_ID").or_else(|| os_release_value(contents, "BUILD_ID"))
+}
+
+fn os_release_value(contents: &str, key: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            return None;
+        }
+
+        let (candidate, value) = line.split_once('=')?;
+        if candidate.trim() != key {
+            return None;
+        }
+
+        Some(unquote_os_release_value(value.trim()).to_string())
+    })
+}
+
+fn unquote_os_release_value(value: &str) -> &str {
+    if let Some(value) = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+    {
+        return value;
+    }
+
+    if let Some(value) = value
+        .strip_prefix('\'')
+        .and_then(|value| value.strip_suffix('\''))
+    {
+        return value;
+    }
+
+    value
 }
 
 impl Display for SupportedOs {
@@ -136,5 +199,47 @@ mod tests {
     fn from_os_bails_on_unsupported() {
         let err = SupportedOs::from_os("windows").unwrap_err();
         assert_eq!(err.to_string(), "Unsupported operating system: windows");
+    }
+
+    #[test]
+    fn parse_os_release_version_prefers_version_id() {
+        let contents = r#"
+            ID=ubuntu
+            VERSION_ID="24.04"
+            BUILD_ID=rolling
+        "#;
+
+        assert_eq!(parse_os_release_version(contents).as_deref(), Some("24.04"));
+    }
+
+    #[test]
+    fn parse_os_release_version_falls_back_to_build_id() {
+        let contents = r#"
+            NAME="Arch Linux"
+            ID=arch
+            BUILD_ID=rolling
+        "#;
+
+        assert_eq!(
+            parse_os_release_version(contents).as_deref(),
+            Some("rolling")
+        );
+    }
+
+    #[test]
+    fn parse_os_release_version_handles_single_quoted_values() {
+        let contents = "ID=example\nVERSION_ID='1.2'\n";
+
+        assert_eq!(parse_os_release_version(contents).as_deref(), Some("1.2"));
+    }
+
+    #[test]
+    fn parse_os_release_version_returns_none_without_version_fields() {
+        let contents = r#"
+            NAME="Unknown Linux"
+            ID=unknown
+        "#;
+
+        assert_eq!(parse_os_release_version(contents), None);
     }
 }


### PR DESCRIPTION
## Summary

Fix local CLI startup on Linux distributions whose os-release data has no VERSION_ID, such as Arch Linux.

The runner now keeps the existing support policy:
- Ubuntu and Debian remain first-class supported distributions.
- Other Linux distributions remain manual-install distributions.
- OS detection no longer fails before executor support can decide what to do.

## Changes

- Move Linux version lookup into a Linux-specific resolver.
- Keep macOS using sysinfo OS version as before.
- For Linux, use sysinfo OS version first, then fall back to VERSION_ID or BUILD_ID from /etc/os-release or /usr/lib/os-release.
- Add unit tests for VERSION_ID preference, BUILD_ID fallback, quoted values, and missing version fields.

## Validation

- cargo fmt --check
- CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/botirk/repos/codspeed-target TMPDIR=/home/botirk/repos/codspeed-tmp cargo check
- CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/botirk/repos/codspeed-target TMPDIR=/home/botirk/repos/codspeed-tmp cargo test --lib system::os
- CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/botirk/repos/codspeed-target TMPDIR=/home/botirk/repos/codspeed-tmp cargo run -- status

On the Arch Linux host that previously failed with Failed to get OS version, status now reports arch rolling and reaches normal repository/tool status output.

Closes #434