### PR TITLE
fix(memory): source forwarded env below memtrack's capability boundary

### DIFF
--- a/src/executor/helpers/run_with_env.rs
+++ b/src/executor/helpers/run_with_env.rs
@@ -36,18 +36,25 @@ pub fn wrap_with_env(
     mut cmd_builder: CommandBuilder,
     extra_env: &HashMap<String, String>,
 ) -> Result<(CommandBuilder, NamedTempFile)> {
-    let env_file = create_env_file(extra_env)?;
-
-    // Create bash command that sources the env file and runs the original command
-    let original_command = cmd_builder.as_command_line();
-    let bash_command = format!(
-        "source {} && {}",
-        env_file.path().display(),
-        original_command
-    );
+    let (bash_command, env_file) =
+        prefix_command_with_env(&cmd_builder.as_command_line(), extra_env)?;
     cmd_builder.wrap("bash", ["-c", &bash_command]);
 
     Ok((cmd_builder, env_file))
+}
+
+/// Prefixes a shell command with a `source` of the forwarded environment.
+///
+/// Unlike [`wrap_with_env`], the returned value is the raw `source <file> && <command>`
+/// snippet without a `bash -c` wrapper, for callers that already run their argument
+/// through a shell.
+pub fn prefix_command_with_env(
+    command: &str,
+    extra_env: &HashMap<String, String>,
+) -> Result<(String, NamedTempFile)> {
+    let env_file = create_env_file(extra_env)?;
+    let wrapped = format!("source {} && {}", env_file.path().display(), command);
+    Ok((wrapped, env_file))
 }
 
 fn create_env_file(extra_env: &HashMap<String, String>) -> Result<NamedTempFile> {

--- a/src/executor/memory/executor.rs
+++ b/src/executor/memory/executor.rs
@@ -6,7 +6,7 @@ use crate::executor::helpers::command::CommandBuilder;
 use crate::executor::helpers::env::{build_path_env, get_base_injected_env};
 use crate::executor::helpers::get_bench_command::get_bench_command;
 use crate::executor::helpers::run_command_with_log_pipe::run_command_with_log_pipe_and_callback;
-use crate::executor::helpers::run_with_env::wrap_with_env;
+use crate::executor::helpers::run_with_env::prefix_command_with_env;
 use crate::executor::helpers::run_with_sudo::is_root_user;
 use crate::executor::shared::fifo::RunnerFifo;
 use crate::executor::{ExecutionContext, Executor};
@@ -53,6 +53,12 @@ impl MemoryExecutor {
         // Setup memtrack IPC server
         let (ipc_server, server_name) = ipc::IpcOneShotServer::new()?;
 
+        // A file-capability binary runs in glibc secure-execution mode, which strips
+        // LD_* variables. The forwarded environment has to be re-sourced below that
+        // boundary, inside the benchmark, to survive.
+        let bench_command = get_bench_command(&execution_context.config)?;
+        let (bench_command, env_file) = prefix_command_with_env(&bench_command, &extra_env)?;
+
         // Build the memtrack command
         let mut cmd_builder = CommandBuilder::new(MEMTRACK_COMMAND);
         cmd_builder.arg("track");
@@ -60,15 +66,13 @@ impl MemoryExecutor {
         cmd_builder.arg(execution_context.profile_folder.join("results"));
         cmd_builder.arg("--ipc-server");
         cmd_builder.arg(server_name);
-        cmd_builder.arg(get_bench_command(&execution_context.config)?);
+        cmd_builder.arg(bench_command);
 
         // Set working directory if specified
         if let Some(cwd) = &execution_context.config.working_directory {
             let abs_cwd = canonicalize(cwd)?;
             cmd_builder.current_dir(abs_cwd);
         }
-
-        let (cmd_builder, env_file) = wrap_with_env(cmd_builder, &extra_env)?;
 
         Ok((ipc_server, cmd_builder, env_file))
     }

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -476,4 +476,35 @@ fi
         })
         .await;
     }
+
+    // Regression: memtrack's file capabilities trigger glibc secure-execution mode,
+    // stripping LD_* before the benchmark inherits it. Guards that a forwarded
+    // LD_LIBRARY_PATH still reaches the benchmark (PATH would not catch this).
+    #[test_log::test(tokio::test)]
+    async fn test_memory_executor_forwards_ld_library_path() {
+        let custom_lib = "/custom/test/lib";
+        let current = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+        let modified = match current.is_empty() {
+            true => custom_lib.to_string(),
+            false => format!("{custom_lib}:{current}"),
+        };
+
+        let cmd = format!(
+            r#"
+if ! echo "$LD_LIBRARY_PATH" | grep -q "{custom_lib}"; then
+  echo "FAIL: LD_LIBRARY_PATH does not contain {custom_lib}"
+  echo "Got LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+  exit 1
+fi
+"#
+        );
+        let config = memory_config(&cmd);
+        let (execution_context, _temp_dir) = create_test_setup(config).await;
+        let (_permit, _lock, mut executor) = get_memory_executor().await;
+
+        temp_env::async_with_vars(&[("LD_LIBRARY_PATH", Some(&modified))], async {
+            executor.run(&execution_context, &None).await.unwrap();
+        })
+        .await;
+    }
 }


### PR DESCRIPTION
## Root cause

`codspeed-memtrack` holds file capabilities (`cap_bpf`, `cap_perfmon`, `cap_sys_admin`). A non-root user executing a capability binary enters glibc **secure-execution mode** (`AT_SECURE=1`), which strips `LD_*` variables from the environment before `main()`.

The memory executor sourced the forwarded environment *around* memtrack:

```
bash -c "source ENV && memtrack track … '<bench>'"   ← LD_LIBRARY_PATH restored here
└─ codspeed-memtrack                                 ← cap binary: glibc strips LD_* again
   └─ bash -c <bench>                                ← inherits stripped env ❌
```

So `LD_LIBRARY_PATH` was restored and then stripped a second time, before the benchmark memtrack spawns could inherit it.

Walltime is unaffected because it layers privilege escalation (`sudo`/`perf`/systemd scope) *outside* the env re-source, keeping `source` at the innermost layer.

## Fix

Source the env *inside* the command memtrack runs via its own `bash -c`, below the capability boundary:

```
codspeed-memtrack track … "source ENV && <bench>"
└─ codspeed-memtrack           ← strips LD_* (no longer matters)
   └─ bash -c "source ENV && <bench>"   ← re-sources below the cap binary
      └─ <bench>                        ← sees LD_LIBRARY_PATH ✅
```

- Add `prefix_command_with_env` for the raw `source <file> && <cmd>` snippet (no outer `bash -c`) and reuse it from `wrap_with_env`.
- `MemoryExecutor::build_memtrack_command` now prefixes the bench command and passes it as memtrack's argument; the outer bash wrapper is gone.

## Test

`test_memory_executor_forwards_ld_library_path` (Linux + `GITHUB_ACTIONS` gated) exercises this end-to-end. The existing `..._forwards_path` test never caught it because `PATH` is not an `LD_*` variable.

> [!NOTE]
> If the memory test suite is ever run as **root**, memtrack's caps add nothing, secure-exec isn't triggered, and the test would pass even with the bug present, same limitation as the real-world scenario, which only affects the non-root `runner` user.

## Verification

Reproduced the mechanism with a minimal capability binary that runs its argument via `bash -c` (memtrack's exact structure), as a non-root user:

| nesting | benchmark sees `LD_LIBRARY_PATH` |
|---|---|
| old (source around cap binary) | empty ❌ |
| new (source inside bench) | `/custom/lib` ✅ |