### PR TITLE
build: bump pinned valgrind-codspeed to 3.26.0-0codspeed6

### DIFF
--- a/src/binary_pins.rs
+++ b/src/binary_pins.rs
@@ -13,7 +13,7 @@ pub const VALGRIND_CODSPEED_VERSION: Version = Version::new(3, 26, 0);
 /// the .deb is repackaged without a new upstream valgrind release. Appears in
 /// the .deb package version (`3.26.0-0codspeed3`) and in `valgrind --version`
 /// output (`valgrind-3.26.0.codspeed3`).
-pub const VALGRIND_CODSPEED_ITERATION: u32 = 5;
+pub const VALGRIND_CODSPEED_ITERATION: u32 = 6;
 /// Suffix appended to `VALGRIND_CODSPEED_VERSION` to form the .deb package version.
 static VALGRIND_DEB_REV: LazyLock<String> =
     LazyLock::new(|| format!("0codspeed{VALGRIND_CODSPEED_ITERATION}"));
@@ -93,16 +93,16 @@ impl ValgrindTarget {
     fn sha256(self) -> &'static str {
         match (self.distro_version, self.arch) {
             (DistroVersion::Ubuntu2204, Arch::Amd64) => {
-                "4cd7bf6092b4480408a93a412b64467c35255805cf42a541580c328102224c93"
+                "d7ca177bbdacf69c4144a822488faca5f2e98b953bacf64831eb3fdbe599fdad"
             }
             (DistroVersion::Ubuntu2404, Arch::Amd64) => {
-                "954ef3451beb544ea54766007fda3d13e17e7298e916108733f69c8487b3a250"
+                "454becce1a232bba1c408ed8aad4a20afa78acfbaba072cef2bf1c0a636ebd71"
             }
             (DistroVersion::Ubuntu2204, Arch::Arm64) => {
-                "7de34b15f9eb672cce9d722033b332d62c9ed6a4295f74062f424fc84a68ba16"
+                "79385d28546f711c4f3c000dbcf50362a2be13b1ce9c7c6746870bfe48ffcedf"
             }
             (DistroVersion::Ubuntu2404, Arch::Arm64) => {
-                "fb15f13f932a82d94b1e01a52acc664aaaf245ee9e6d50ae92370de9a557a954"
+                "47e71ef8a095a8dc26e31e7a5d66c3665ff2d68a3f0350d351d7affe3aec2944"
             }
         }
     }

--- a/src/executor/valgrind/setup.rs
+++ b/src/executor/valgrind/setup.rs
@@ -234,7 +234,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed5/valgrind_3.26.0-0codspeed5_ubuntu-22.04_amd64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-22.04_amd64.deb"
         );
     }
 
@@ -249,7 +249,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed5/valgrind_3.26.0-0codspeed5_ubuntu-24.04_amd64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-24.04_amd64.deb"
         );
     }
 
@@ -264,7 +264,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed5/valgrind_3.26.0-0codspeed5_ubuntu-22.04_amd64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-22.04_amd64.deb"
         );
     }
 
@@ -279,7 +279,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed5/valgrind_3.26.0-0codspeed5_ubuntu-22.04_arm64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-22.04_arm64.deb"
         );
     }
 


### PR DESCRIPTION
Bump the pinned valgrind-codspeed build from `3.26.0-0codspeed5` to `3.26.0-0codspeed6`: iteration const, the four `.deb` SHA-256 pins, and the URL snapshots.

Picks up the latest CodSpeed valgrind repackaging so runs install the new build. Hashes verified against the release assets via `GITHUB_ACTIONS=true cargo test all_pinned`.