### PR TITLE
feat: enable cycle estimation and allocation exclusion by default

### DIFF
--- a/src/cli/exec/mod.rs
+++ b/src/cli/exec/mod.rs
@@ -90,8 +90,8 @@ fn build_orchestrator_config(
         poll_results_options,
         extra_env: HashMap::new(),
         fair_sched: args.shared.experimental.experimental_fair_sched,
-        cycle_estimation: args.shared.experimental.experimental_cycle_estimation,
-        exclude_allocations: args.shared.experimental.experimental_exclude_allocations,
+        cycle_estimation: args.shared.cycle_estimation,
+        exclude_allocations: args.shared.exclude_allocations,
     })
 }
 

--- a/src/cli/experimental.rs
+++ b/src/cli/experimental.rs
@@ -17,22 +17,12 @@ pub struct ExperimentalArgs {
     )]
     pub experimental_fair_sched: bool,
 
-    /// Enable Valgrind cycle estimation (--cycle-estimation) in simulation mode.
-    #[arg(
-        long,
-        default_value_t = false,
-        help_heading = "Experimental",
-        env = "CODSPEED_EXPERIMENTAL_CYCLE_ESTIMATION"
-    )]
+    /// Deprecated: cycle estimation is enabled by default and this flag has no effect.
+    #[arg(long, hide = true, env = "CODSPEED_EXPERIMENTAL_CYCLE_ESTIMATION")]
     pub experimental_cycle_estimation: bool,
 
-    /// Exclude memory allocation time from simulation results.
-    #[arg(
-        long,
-        default_value_t = false,
-        help_heading = "Experimental",
-        env = "CODSPEED_EXPERIMENTAL_EXCLUDE_ALLOCATIONS"
-    )]
+    /// Deprecated: allocation exclusion is enabled by default and this flag has no effect.
+    #[arg(long, hide = true, env = "CODSPEED_EXPERIMENTAL_EXCLUDE_ALLOCATIONS")]
     pub experimental_exclude_allocations: bool,
 }
 
@@ -42,12 +32,6 @@ impl ExperimentalArgs {
         let mut flags = Vec::new();
         if self.experimental_fair_sched {
             flags.push("--experimental-fair-sched");
-        }
-        if self.experimental_cycle_estimation {
-            flags.push("--experimental-cycle-estimation");
-        }
-        if self.experimental_exclude_allocations {
-            flags.push("--experimental-exclude-allocations");
         }
         flags
     }
@@ -73,5 +57,34 @@ impl ExperimentalArgs {
             flag_list,
             style("https://github.com/CodSpeedHQ/codspeed/issues").underlined(),
         );
+    }
+
+    /// Warns about deprecated flags that were graduated to default-on options and
+    /// no longer have any effect.
+    pub fn warn_if_deprecated(&self) {
+        let deprecated = [
+            (
+                self.experimental_cycle_estimation,
+                "--experimental-cycle-estimation",
+                "cycle estimation",
+                "--cycle-estimation",
+            ),
+            (
+                self.experimental_exclude_allocations,
+                "--experimental-exclude-allocations",
+                "allocation exclusion",
+                "--exclude-allocations",
+            ),
+        ];
+
+        for (_, flag, feature, new_flag) in deprecated.iter().filter(|(set, ..)| *set) {
+            eprintln!(
+                "  {} {} has no effect: {} is now controlled by {} (defaults to true).",
+                style(Icon::Warning.to_string()).yellow(),
+                style(*flag).bold(),
+                feature,
+                style(*new_flag).bold(),
+            );
+        }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -171,6 +171,7 @@ pub async fn run() -> Result<()> {
                 .upload_url
                 .get_or_insert_with(|| codspeed_config.upload_url.clone());
             args.shared.experimental.warn_if_active();
+            args.shared.experimental.warn_if_deprecated();
             run::run(
                 args,
                 &mut api_client,
@@ -185,6 +186,7 @@ pub async fn run() -> Result<()> {
                 .upload_url
                 .get_or_insert_with(|| codspeed_config.upload_url.clone());
             args.shared.experimental.warn_if_active();
+            args.shared.experimental.warn_if_deprecated();
             exec::run(
                 args,
                 &mut api_client,

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -69,6 +69,8 @@ impl RunArgs {
                 go_runner_version: None,
                 show_full_output: false,
                 base: None,
+                cycle_estimation: true,
+                exclude_allocations: true,
                 profiler_run_args: ProfilerRunArgs {
                     enable_profiler: false,
                     enable_perf: None,
@@ -129,8 +131,8 @@ fn build_orchestrator_config(
         poll_results_options,
         extra_env: HashMap::new(),
         fair_sched: args.shared.experimental.experimental_fair_sched,
-        cycle_estimation: args.shared.experimental.experimental_cycle_estimation,
-        exclude_allocations: args.shared.experimental.experimental_exclude_allocations,
+        cycle_estimation: args.shared.cycle_estimation,
+        exclude_allocations: args.shared.exclude_allocations,
     })
 }
 

--- a/src/cli/shared.rs
+++ b/src/cli/shared.rs
@@ -113,6 +113,24 @@ pub struct ExecAndRunSharedArgs {
     #[arg(long)]
     pub base: Option<String>,
 
+    /// Enable Valgrind cycle estimation (--cycle-estimation) in simulation mode.
+    #[arg(
+        long,
+        env = "CODSPEED_CYCLE_ESTIMATION",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
+    pub cycle_estimation: bool,
+
+    /// Exclude memory allocation time from simulation results.
+    #[arg(
+        long,
+        env = "CODSPEED_EXCLUDE_ALLOCATIONS",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
+    pub exclude_allocations: bool,
+
     #[command(flatten)]
     pub profiler_run_args: ProfilerRunArgs,
 

--- a/src/executor/config.rs
+++ b/src/executor/config.rs
@@ -235,8 +235,8 @@ impl OrchestratorConfig {
             poll_results_options: PollResultsOptions::new(false, None),
             extra_env: HashMap::new(),
             fair_sched: false,
-            cycle_estimation: false,
-            exclude_allocations: false,
+            cycle_estimation: true,
+            exclude_allocations: true,
         }
     }
 }

--- a/src/upload/interfaces.rs
+++ b/src/upload/interfaces.rs
@@ -34,8 +34,8 @@ pub struct Runner {
     /// Whether memory allocation time is excluded from results. Part of the run's
     /// measurement configuration: runs with different values are not comparable.
     ///
-    /// Skipped when `false` so the default payload stays byte-identical to runs
-    /// without this feature, keeping the metadata hash and version unchanged.
+    /// Skipped when `false` so the opt-out path (`--exclude-allocations=false`)
+    /// stays byte-identical to legacy runs that predate this field.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub exclude_allocations: bool,
     #[serde(flatten)]


### PR DESCRIPTION
## Summary

Graduate `--cycle-estimation` and `--exclude-allocations` out of the experimental flag set so both simulation behaviors are enabled for everyone by default.

- Both are now normal (non-experimental) options with `default_value_t = true`.
- They remain toggleable escape hatches: `--cycle-estimation=false` / `--exclude-allocations=false` (or env `CODSPEED_CYCLE_ESTIMATION`, `CODSPEED_EXCLUDE_ALLOCATIONS`) disable them.
- Dropped from the `Experimental` help heading and no longer trigger the experimental-flags warning.
- `--experimental-fair-sched` is intentionally left untouched (still experimental, default off).

## Changes

| File | Change |
|---|---|
| `src/cli/shared.rs` | Add `cycle_estimation` / `exclude_allocations` toggleable bools (default true, `require_equals`) to `ExecAndRunSharedArgs` |
| `src/cli/experimental.rs` | Remove both from `ExperimentalArgs`; only `experimental_fair_sched` remains |
| `src/cli/run/mod.rs`, `src/cli/exec/mod.rs` | Read the new shared fields |
| `src/executor/config.rs` | `OrchestratorConfig::test()` defaults both true |

## Behavior note

`Runner.exclude_allocations` in upload metadata now serializes `true` on every simulation run (previously omitted via `skip_serializing_if`). This is the intended signal, just always present now.

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets` clean.
- Verified via the built binary: `--cycle-estimation`, `--cycle-estimation=false`, and `--exclude-allocations=false` all parse; help lists both as normal options.
- Pre-existing `Unsupported system` valgrind-executor test failures are environment-gated (unsupported valgrind host) and unrelated to this change.