### PR TITLE
chore(memtrack): lower on-demand attach log to debug

### DIFF
--- a/crates/memtrack/src/ebpf/attach_worker.rs
+++ b/crates/memtrack/src/ebpf/attach_worker.rs
@@ -249,7 +249,7 @@ impl Worker {
             );
         }
 
-        info!(
+        debug!(
             "on-demand attached {} probes to {}",
             kind.name(),
             mapping.display


### PR DESCRIPTION
## Summary

Downgrades the per-attach "on-demand attached N probes to ..." log from `info!` to `debug!` in `attach_worker.rs`.

This message fires once per successfully attached mapping during on-demand allocator attachment, which is too noisy for the default `info` level. It belongs at `debug`.

## Testing

- `cargo build`