### PR TITLE
build: bump the memtrack pin to 1.4.0

### DIFF
--- a/src/binary_pins.rs
+++ b/src/binary_pins.rs
@@ -109,9 +109,9 @@ impl ValgrindTarget {
 }
 
 const MEMTRACK_INSTALLER: BinaryPin = BinaryPin {
-    version: "1.3.0",
+    version: "1.4.0",
     url_template: "https://github.com/CodSpeedHQ/codspeed/releases/download/memtrack-v{version}/memtrack-installer.sh",
-    sha256: "4f11854e4e030962ad1a05dbf5452777286053ca31cdd2bb3ae59b7149870a8b",
+    sha256: "bbc6aac54bac8ec93c1f37ce341811b02ab31e39a211cf6c80a2ee80c2f088f6",
 };
 #[cfg(target_os = "linux")]
 pub const MEMTRACK_VERSION: &str = MEMTRACK_INSTALLER.version;


### PR DESCRIPTION
Point the runner at the [memtrack-v1.4.0](https://github.com/CodSpeedHQ/codspeed/releases/tag/memtrack-v1.4.0) release, so runs pick up eBPF loading through a delegated BPF token and the mapped-library classification fix for environments without init-userns privilege (both from #456).

Heads up on CI: `all_pinned_binaries_match_their_declared_sha256` currently fails on an unrelated pin. GitHub serves a persistent `500` for `releases/download/exec-harness-v1.3.0/exec-harness-installer.sh` while the same asset over the API (`releases/assets/407413621`) returns `200`, and every other asset on that release is fine. Nothing to do with this diff, but it also means runner installs of exec-harness are failing right now.
