### PR TITLE
chore: make samply debug info server timeout much shorter

### DIFF
--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -127,7 +127,6 @@ fi
             let path = escargot::CargoBuild::new()
                 .package(package)
                 .bin(bin)
-                .release()
                 .current_target()
                 .run()
                 .unwrap_or_else(|e| panic!("failed to build the {bin} binary: {e}"))


### PR DESCRIPTION
Related: https://github.com/CodSpeedHQ/samply-codspeed/commit/a8ac4c91c2278891c1457e907a69a66ed7909314