### PR TITLE
docs(readme): bump action version to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ jobs:
       - run: pip install -r requirements.txt
 
       # Run benchmarks with CodSpeed
-      - uses: CodSpeedHQ/action@v4
+      - uses: CodSpeedHQ/action@v5
         with:
           mode: instrumentation
           run: pytest tests/ --codspeed


### PR DESCRIPTION
v5.0.0 is out, so the README GitHub Actions snippet now points at it.

Refs COD-3244 (kept open, it tracks the runner release itself)
