### PR TITLE
chore: make --exclude-allocations nicer to use

### DIFF
--- a/src/cli/experimental.rs
+++ b/src/cli/experimental.rs
@@ -21,7 +21,7 @@ pub struct ExperimentalArgs {
     #[arg(long, hide = true, env = "CODSPEED_EXPERIMENTAL_CYCLE_ESTIMATION")]
     pub experimental_cycle_estimation: bool,
 
-    /// Deprecated: allocation exclusion is enabled by default and this flag has no effect.
+    /// Deprecated: allocation exclusion is controlled by `--exclude-allocations` and this flag has no effect.
     #[arg(long, hide = true, env = "CODSPEED_EXPERIMENTAL_EXCLUDE_ALLOCATIONS")]
     pub experimental_exclude_allocations: bool,
 }
@@ -79,7 +79,7 @@ impl ExperimentalArgs {
 
         for (_, flag, feature, new_flag) in deprecated.iter().filter(|(set, ..)| *set) {
             eprintln!(
-                "  {} {} has no effect: {} is now controlled by {} (defaults to true).",
+                "  {} {} has no effect: {} is now controlled by {}.",
                 style(Icon::Warning.to_string()).yellow(),
                 style(*flag).bold(),
                 feature,

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -70,7 +70,7 @@ impl RunArgs {
                 show_full_output: false,
                 base: None,
                 cycle_estimation: true,
-                exclude_allocations: true,
+                exclude_allocations: false,
                 profiler_run_args: ProfilerRunArgs {
                     enable_profiler: false,
                     enable_perf: None,

--- a/src/cli/shared.rs
+++ b/src/cli/shared.rs
@@ -118,7 +118,9 @@ pub struct ExecAndRunSharedArgs {
         long,
         env = "CODSPEED_CYCLE_ESTIMATION",
         default_value_t = true,
-        action = clap::ArgAction::Set
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true"
     )]
     pub cycle_estimation: bool,
 
@@ -126,8 +128,10 @@ pub struct ExecAndRunSharedArgs {
     #[arg(
         long,
         env = "CODSPEED_EXCLUDE_ALLOCATIONS",
-        default_value_t = false,
-        action = clap::ArgAction::Set
+        default_value = "false",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true"
     )]
     pub exclude_allocations: bool,
 

--- a/src/executor/config.rs
+++ b/src/executor/config.rs
@@ -236,7 +236,7 @@ impl OrchestratorConfig {
             extra_env: HashMap::new(),
             fair_sched: false,
             cycle_estimation: true,
-            exclude_allocations: true,
+            exclude_allocations: false,
         }
     }
 }

--- a/src/upload/interfaces.rs
+++ b/src/upload/interfaces.rs
@@ -34,8 +34,8 @@ pub struct Runner {
     /// Whether memory allocation time is excluded from results. Part of the run's
     /// measurement configuration: runs with different values are not comparable.
     ///
-    /// Skipped when `false` so the opt-out path (`--exclude-allocations=false`)
-    /// stays byte-identical to legacy runs that predate this field.
+    /// Skipped when `false` so runs that don't exclude allocations stay
+    /// byte-identical to legacy runs that predate this field.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub exclude_allocations: bool,
     #[serde(flatten)]


### PR DESCRIPTION
Before you had to pass =true or =false instead of just using --exclude-allocations