### PR TITLE
Add runner options to enable valgrind subprocess tracking

### DIFF
--- a/crates/exec-harness/src/analysis/mod.rs
+++ b/crates/exec-harness/src/analysis/mod.rs
@@ -6,7 +6,6 @@ use crate::BenchmarkCommand;
 use crate::constants;
 use crate::uri;
 use instrument_hooks_bindings::InstrumentHooks;
-use std::path::PathBuf;
 use std::process::Command;
 
 mod ld_preload_check;
@@ -65,8 +64,6 @@ pub fn perform_with_valgrind(commands: Vec<BenchmarkCommand>) -> Result<()> {
 
         let status = child.wait().context("Failed to execute command")?;
 
-        bail_if_command_spawned_subprocesses_under_valgrind(child.id())?;
-
         if !status.success() {
             bail!("Command exited with non-zero status: {status}");
         }
@@ -75,47 +72,3 @@ pub fn perform_with_valgrind(commands: Vec<BenchmarkCommand>) -> Result<()> {
     Ok(())
 }
 
-/// Checks if the benchmark process spawned subprocesses under valgrind by looking for <pid>.out
-/// files in the profile folder.
-///
-/// The presence of <pid>.out files where <pid> is greater than the benchmark process pid indicates
-/// that the benchmark process spawned subprocesses. This .out file will be almost empty, with a 0
-/// cost reported due to the disabled instrumentation.
-///
-/// We currently do not support measuring processes that spawn subprocesses under valgrind, because
-/// valgrind will not have its instrumentation in the new process.
-/// The LD_PRELOAD trick that we use to inject our instrumentation into the benchmark process only
-/// works for the first process.
-///
-/// TODO(COD-2163): Remove this once we support nested processes under valgrind
-fn bail_if_command_spawned_subprocesses_under_valgrind(pid: u32) -> Result<()> {
-    let Some(profile_folder) = std::env::var_os("CODSPEED_PROFILE_FOLDER") else {
-        debug!("CODSPEED_PROFILE_FOLDER is not set, skipping subprocess detection");
-        return Ok(());
-    };
-
-    let profile_folder = PathBuf::from(profile_folder);
-
-    // Bail if any <pid>.out where <pid> > pid of the benchmark process exists in the profile
-    // folder, which indicates that the benchmark process spawned subprocesses.
-    for entry in std::fs::read_dir(profile_folder)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let file_name = file_name.to_string_lossy();
-
-        if let Some(stripped) = file_name.strip_suffix(".out") {
-            if let Ok(subprocess_pid) = stripped.parse::<u32>() {
-                if subprocess_pid > pid {
-                    bail!(
-                        "The codspeed CLI in CPU Simulation mode does not support measuring processes that spawn other processes yet.\n\n\
-                         Please either:\n\
-                         - Use the walltime measurement mode, or\n\
-                         - Benchmark a process that does not create subprocesses"
-                    )
-                }
-            }
-        }
-    }
-
-    Ok(())
-}

--- a/crates/exec-harness/src/analysis/mod.rs
+++ b/crates/exec-harness/src/analysis/mod.rs
@@ -71,4 +71,3 @@ pub fn perform_with_valgrind(commands: Vec<BenchmarkCommand>) -> Result<()> {
 
     Ok(())
 }
-

--- a/src/cli/exec/mod.rs
+++ b/src/cli/exec/mod.rs
@@ -92,6 +92,7 @@ fn build_orchestrator_config(
         fair_sched: args.shared.experimental.experimental_fair_sched,
         cycle_estimation: args.shared.cycle_estimation,
         exclude_allocations: args.shared.exclude_allocations,
+        simulation_track_subprocess: args.shared.simulation_track_subprocess,
     })
 }
 

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -71,6 +71,7 @@ impl RunArgs {
                 base: None,
                 cycle_estimation: true,
                 exclude_allocations: false,
+                simulation_track_subprocess: false,
                 profiler_run_args: ProfilerRunArgs {
                     enable_profiler: false,
                     enable_perf: None,
@@ -133,6 +134,7 @@ fn build_orchestrator_config(
         fair_sched: args.shared.experimental.experimental_fair_sched,
         cycle_estimation: args.shared.cycle_estimation,
         exclude_allocations: args.shared.exclude_allocations,
+        simulation_track_subprocess: args.shared.simulation_track_subprocess,
     })
 }
 

--- a/src/cli/shared.rs
+++ b/src/cli/shared.rs
@@ -135,6 +135,15 @@ pub struct ExecAndRunSharedArgs {
     )]
     pub exclude_allocations: bool,
 
+    /// Measure the subprocesses spawned by the benchmarked process in simulation mode.
+    #[arg(
+        long,
+        env = "CODSPEED_SIMULATION_TRACK_SUBPROCESS",
+        default_value_t = false,
+        action = clap::ArgAction::Set
+    )]
+    pub simulation_track_subprocess: bool,
+
     #[command(flatten)]
     pub profiler_run_args: ProfilerRunArgs,
 

--- a/src/executor/config.rs
+++ b/src/executor/config.rs
@@ -95,6 +95,9 @@ pub struct OrchestratorConfig {
     pub cycle_estimation: bool,
     /// Signal the backend to exclude memory allocation time from simulation results.
     pub exclude_allocations: bool,
+    /// Inherit valgrind's instrumentation state across a traced exec, so the cost of
+    /// subprocesses spawned by a benchmark is measured too.
+    pub simulation_track_subprocess: bool,
 }
 
 /// Per-execution configuration passed to executors.
@@ -132,6 +135,9 @@ pub struct ExecutorConfig {
     pub cycle_estimation: bool,
     /// Signal the backend to exclude memory allocation time from simulation results.
     pub exclude_allocations: bool,
+    /// Inherit valgrind's instrumentation state across a traced exec, so the cost of
+    /// subprocesses spawned by a benchmark is measured too.
+    pub simulation_track_subprocess: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -203,6 +209,7 @@ impl OrchestratorConfig {
             fair_sched: self.fair_sched,
             cycle_estimation: self.cycle_estimation,
             exclude_allocations: self.exclude_allocations,
+            simulation_track_subprocess: self.simulation_track_subprocess,
         }
     }
 }
@@ -237,6 +244,7 @@ impl OrchestratorConfig {
             fair_sched: false,
             cycle_estimation: true,
             exclude_allocations: false,
+            simulation_track_subprocess: false,
         }
     }
 }

--- a/src/executor/valgrind/measure.rs
+++ b/src/executor/valgrind/measure.rs
@@ -26,7 +26,6 @@ fn get_valgrind_args(tool: &SimulationTool, config: &ExecutorConfig) -> Vec<Stri
         "--I1=32768,8,64",
         "--D1=32768,8,64",
         "--LL=8388608,16,64",
-        "--instr-atstart=no",
         "--collect-systime=nsec",
         "--read-inline-info=yes",
     ]
@@ -34,10 +33,19 @@ fn get_valgrind_args(tool: &SimulationTool, config: &ExecutorConfig) -> Vec<Stri
     .map(|x| x.to_string())
     .collect();
 
+    args.push(if config.simulation_track_subprocess {
+        "--instr-atstart=inherit".to_string()
+    } else {
+        "--instr-atstart=no".to_string()
+    });
+
     match tool {
         SimulationTool::Callgrind => {
             if config.cycle_estimation {
                 args.push("--cycle-estimation=yes".to_string());
+                args.push("--separate-threads=yes".to_string());
+            } else {
+                args.push("--separate-threads=no".to_string());
             }
 
             args.push("--tool=callgrind".to_string());

--- a/src/executor/valgrind/measure.rs
+++ b/src/executor/valgrind/measure.rs
@@ -58,8 +58,7 @@ fn get_valgrind_args(tool: &SimulationTool, config: &ExecutorConfig) -> Vec<Stri
         }
     }
 
-    // Valgrind changes argv[0] when tracing Nix's rustup wrapper, which breaks rustup proxy detection.
-    let children_skip_patterns = ["*esbuild", "*.rustup-wrapped"];
+    let children_skip_patterns = ["*esbuild"];
     args.push(format!(
         "--trace-children-skip={}",
         children_skip_patterns.join(",")
@@ -246,18 +245,6 @@ mod tests {
             .unwrap();
 
         (script_status, out_status)
-    }
-
-    #[test]
-    fn test_valgrind_skips_rustup_wrapped_proxy() {
-        let config = ExecutorConfig::test();
-        let args = get_valgrind_args(&SimulationTool::Callgrind, &config);
-        let skip_arg = args
-            .iter()
-            .find(|arg| arg.starts_with("--trace-children-skip="))
-            .unwrap();
-
-        assert!(skip_arg.contains("*.rustup-wrapped"));
     }
 
     #[test]


### PR DESCRIPTION
Related: https://github.com/CodSpeedHQ/valgrind-codspeed/pull/25

Not to be merged until valgrind-codspeed has been released and required version has been bumped