### PR TITLE
chore: bump pinned valgrind-codspeed to 3.26.0-0codspeed7

### DIFF
--- a/src/binary_pins.rs
+++ b/src/binary_pins.rs
@@ -13,7 +13,7 @@ pub const VALGRIND_CODSPEED_VERSION: Version = Version::new(3, 26, 0);
 /// the .deb is repackaged without a new upstream valgrind release. Appears in
 /// the .deb package version (`3.26.0-0codspeed3`) and in `valgrind --version`
 /// output (`valgrind-3.26.0.codspeed3`).
-pub const VALGRIND_CODSPEED_ITERATION: u32 = 6;
+pub const VALGRIND_CODSPEED_ITERATION: u32 = 7;
 /// Suffix appended to `VALGRIND_CODSPEED_VERSION` to form the .deb package version.
 static VALGRIND_DEB_REV: LazyLock<String> =
     LazyLock::new(|| format!("0codspeed{VALGRIND_CODSPEED_ITERATION}"));
@@ -93,16 +93,16 @@ impl ValgrindTarget {
     fn sha256(self) -> &'static str {
         match (self.distro_version, self.arch) {
             (DistroVersion::Ubuntu2204, Arch::Amd64) => {
-                "d7ca177bbdacf69c4144a822488faca5f2e98b953bacf64831eb3fdbe599fdad"
+                "658a64049b6a1f5bec9c038b8036f9a61fee83011a909b649e32a82edab4ba99"
             }
             (DistroVersion::Ubuntu2404, Arch::Amd64) => {
-                "454becce1a232bba1c408ed8aad4a20afa78acfbaba072cef2bf1c0a636ebd71"
+                "ea1788e43cfd75b8af84dd496eb265307c6ab6d048cb7bc8ba4bc564dbbd5aba"
             }
             (DistroVersion::Ubuntu2204, Arch::Arm64) => {
-                "79385d28546f711c4f3c000dbcf50362a2be13b1ce9c7c6746870bfe48ffcedf"
+                "6db07f15ce23e3cfda00bda85aac0ea3b8a2261c00d529ed856ceb7f3ba207f6"
             }
             (DistroVersion::Ubuntu2404, Arch::Arm64) => {
-                "47e71ef8a095a8dc26e31e7a5d66c3665ff2d68a3f0350d351d7affe3aec2944"
+                "0bccdaf2da7202ff4fe15e8301641c3a0abd46879c03713150cb5f21d6c9baaf"
             }
         }
     }

--- a/src/executor/valgrind/setup.rs
+++ b/src/executor/valgrind/setup.rs
@@ -284,7 +284,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-22.04_amd64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed7/valgrind_3.26.0-0codspeed7_ubuntu-22.04_amd64.deb"
         );
     }
 
@@ -299,7 +299,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-24.04_amd64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed7/valgrind_3.26.0-0codspeed7_ubuntu-24.04_amd64.deb"
         );
     }
 
@@ -314,7 +314,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-22.04_amd64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed7/valgrind_3.26.0-0codspeed7_ubuntu-22.04_amd64.deb"
         );
     }
 
@@ -329,7 +329,7 @@ mod tests {
         };
         assert_snapshot!(
             get_codspeed_valgrind_binary(&system_info).unwrap().url(),
-            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed6/valgrind_3.26.0-0codspeed6_ubuntu-22.04_arm64.deb"
+            @"https://github.com/CodSpeedHQ/valgrind-codspeed/releases/download/3.26.0-0codspeed7/valgrind_3.26.0-0codspeed7_ubuntu-22.04_arm64.deb"
         );
     }
 


### PR DESCRIPTION
Bump the pinned valgrind-codspeed .deb to [3.26.0-0codspeed7](https://github.com/CodSpeedHQ/valgrind-codspeed/releases/tag/3.26.0-0codspeed7), which brings callgrind subprocess tracking across fork and exec, and os threads represented under `--separate-threads=yes`.

Refs COD-3317 — that issue tracks the 5.2.0 release, which happens once this lands on a green `main`.
