### PR TITLE
ci(memtrack): benchmark memtrack's own tracking overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,32 @@ jobs:
           mode: ${{ matrix.mode }}
           run: cargo codspeed run -p runner-shared
 
+  memtrack-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-bpf-deps
+
+      - name: Install memtrack
+        run: |
+          cargo install --path crates/memtrack --locked
+
+      - name: Grant memtrack file capabilities
+        run: cargo r -- setup --mode memory
+
+      - name: Build the codspeed CLI
+        run: cargo build --release
+
+      - name: Prepare memtrack output directory
+        run: mkdir -p /tmp/codspeed-memtrack-bench
+
+      - name: Run memtrack walltime benchmarks
+        run: ./target/release/codspeed --config crates/memtrack/codspeed.yml run -m walltime
+
   check:
     runs-on: ubuntu-latest
     if: always()
@@ -164,6 +190,7 @@ jobs:
       - macos-basic-run-test
       - bpf-tests
       - benchmarks
+      - memtrack-benchmarks
     steps:
       - uses: re-actors/alls-green@release/v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,13 @@ jobs:
       - name: Prepare memtrack output directory
         run: mkdir -p /tmp/codspeed-memtrack-bench
 
+      # The write benchmarks overwrite these archives every round; creating
+      # them inside a measured round would time one-off disk allocation.
+      - name: Pre-create benchmark archives
+        run: |
+          tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu
+          dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null
+
       - name: Run memtrack walltime benchmarks
         run: ./target/release/codspeed --config crates/memtrack/codspeed.yml run -m walltime
 

--- a/crates/memtrack/codspeed.yml
+++ b/crates/memtrack/codspeed.yml
@@ -1,0 +1,25 @@
+$schema: https://raw.githubusercontent.com/CodSpeedHQ/codspeed/refs/heads/main/schemas/codspeed.schema.json
+
+# Walltime benchmarks measuring codspeed-memtrack's own overhead (eBPF probe
+# attach + tracking) across a few representative workloads, not the memory
+# usage of the tracked command.
+#
+# The warmup/max times are generous because a single tracked run already pays a
+# fixed BPF load + uprobe attach cost, which is far above the defaults tuned
+# for near-instant commands.
+options:
+  warmup-time: "5s"
+  max-time: "60s"
+
+benchmarks:
+  # Read-only, low-allocation baseline.
+  - name: "memtrack track ls"
+    exec: codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+
+  # Allocation- and I/O-heavy: many small file reads.
+  - name: "memtrack track tar"
+    exec: codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+
+  # I/O-heavy with minimal allocation.
+  - name: "memtrack track dd"
+    exec: codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64" --output /tmp/codspeed-memtrack-bench

--- a/crates/memtrack/codspeed.yml
+++ b/crates/memtrack/codspeed.yml
@@ -1,8 +1,9 @@
 $schema: https://raw.githubusercontent.com/CodSpeedHQ/codspeed/refs/heads/main/schemas/codspeed.schema.json
 
-# Walltime benchmarks measuring codspeed-memtrack's own overhead (eBPF probe
-# attach + tracking) across a few representative workloads, not the memory
-# usage of the tracked command.
+# Walltime benchmarks measure codspeed-memtrack's own overhead across a few
+# representative workloads, not the memory usage of the tracked command. Each
+# workload runs both RSS-only and RSS+rmap variants so rmap's overhead is
+# directly comparable.
 #
 # The warmup/max times are generous because a single tracked run already pays a
 # fixed BPF load + uprobe attach cost, which is far above the defaults tuned
@@ -16,12 +17,21 @@ benchmarks:
   # through `bash -c`, so output can be redirected away: otherwise every round
   # dumps the whole listing into the runner log.
   - name: "memtrack track ls"
-    exec: codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
+    exec: CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
 
   # Allocation- and I/O-heavy: many small file reads.
   - name: "memtrack track tar"
-    exec: codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+    exec: CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
 
   # I/O-heavy with minimal allocation.
   - name: "memtrack track dd"
-    exec: codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
+    exec: CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
+
+  - name: "memtrack track ls (rmap)"
+    exec: CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
+
+  - name: "memtrack track tar (rmap)"
+    exec: CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+
+  - name: "memtrack track dd (rmap)"
+    exec: CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench

--- a/crates/memtrack/codspeed.yml
+++ b/crates/memtrack/codspeed.yml
@@ -2,12 +2,16 @@ $schema: https://raw.githubusercontent.com/CodSpeedHQ/codspeed/refs/heads/main/s
 
 # Walltime benchmarks measure codspeed-memtrack's own overhead across a few
 # representative workloads, not the memory usage of the tracked command. Each
-# workload runs both RSS-only and RSS+rmap variants so rmap's overhead is
-# directly comparable.
+# workload's RSS-only and RSS+rmap variants run back to back so rmap's overhead
+# is directly comparable.
 #
 # The warmup/max times are generous because a single tracked run already pays a
 # fixed BPF load + uprobe attach cost, which is far above the defaults tuned
 # for near-instant commands.
+#
+# The write workloads overwrite archives pre-created by CI before measurement:
+# a first-time multi-GB allocation on the runner disk would dominate one
+# variant's warmup round purely from I/O ordering, not tracking overhead.
 options:
   warmup-time: "5s"
   max-time: "60s"
@@ -19,19 +23,19 @@ benchmarks:
   - name: "memtrack track ls"
     exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
 
-  # Allocation- and I/O-heavy: many small file reads.
-  - name: "memtrack track tar"
-    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+  - name: "memtrack track ls (rmap)"
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
 
   # I/O-heavy with minimal allocation.
   - name: "memtrack track dd"
     exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
 
-  - name: "memtrack track ls (rmap)"
-    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
+  - name: "memtrack track dd (rmap)"
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
+
+  # Allocation- and I/O-heavy: many small file reads.
+  - name: "memtrack track tar"
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
 
   - name: "memtrack track tar (rmap)"
     exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
-
-  - name: "memtrack track dd (rmap)"
-    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench

--- a/crates/memtrack/codspeed.yml
+++ b/crates/memtrack/codspeed.yml
@@ -17,21 +17,21 @@ benchmarks:
   # through `bash -c`, so output can be redirected away: otherwise every round
   # dumps the whole listing into the runner log.
   - name: "memtrack track ls"
-    exec: CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
 
   # Allocation- and I/O-heavy: many small file reads.
   - name: "memtrack track tar"
-    exec: CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
 
   # I/O-heavy with minimal allocation.
   - name: "memtrack track dd"
-    exec: CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=0 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
 
   - name: "memtrack track ls (rmap)"
-    exec: CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
 
   - name: "memtrack track tar (rmap)"
-    exec: CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "tar -cf /tmp/memtrack-bench.tar /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
 
   - name: "memtrack track dd (rmap)"
-    exec: CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench
+    exec: env CODSPEED_MEMTRACK_TRACK_RMAP=1 codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench

--- a/crates/memtrack/codspeed.yml
+++ b/crates/memtrack/codspeed.yml
@@ -12,9 +12,11 @@ options:
   max-time: "60s"
 
 benchmarks:
-  # Read-only, low-allocation baseline.
+  # Read-only, low-allocation baseline. The tracked command string is run
+  # through `bash -c`, so output can be redirected away: otherwise every round
+  # dumps the whole listing into the runner log.
   - name: "memtrack track ls"
-    exec: codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu" --output /tmp/codspeed-memtrack-bench
+    exec: codspeed-memtrack track "ls -la /usr/lib/x86_64-linux-gnu > /dev/null" --output /tmp/codspeed-memtrack-bench
 
   # Allocation- and I/O-heavy: many small file reads.
   - name: "memtrack track tar"
@@ -22,4 +24,4 @@ benchmarks:
 
   # I/O-heavy with minimal allocation.
   - name: "memtrack track dd"
-    exec: codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64" --output /tmp/codspeed-memtrack-bench
+    exec: codspeed-memtrack track "dd if=/dev/zero of=/tmp/memtrack-bench-dd.bin bs=1M count=64 2> /dev/null" --output /tmp/codspeed-memtrack-bench


### PR DESCRIPTION
Add walltime benchmarks that measure `codspeed-memtrack`'s own tracking overhead.

The memory benchmarks only report the tracked program's numbers, so the tracker's
fixed costs (BPF load, uprobe attach, ring-buffer drain, event encoding) were
invisible: regressions in the tracker itself looked like noise in the workload.
Each benchmark times a full `codspeed-memtrack track` invocation of a
representative command (`ls`, `dd`, `tar`) through the walltime instrument.

Every workload runs twice — RSS-only and RSS+rmap — so rmap's overhead is directly
comparable in CI instead of being benchmarked by hand on random machines. The
tracked commands redirect their output away and run with generous warmup/max
times, since one tracked run already pays the fixed BPF setup cost.

Stacked follow-up will use these benches to drive and verify tracking-overhead
reductions.

Refs COD-3179
